### PR TITLE
Symbolic wrappers

### DIFF
--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -96,7 +96,7 @@ set_optimizer_attribute(model, "print_level", 0)
 
 # Define the objective
 @objective(model, Min, sum(α[c] * x[c] for c in C) +
-           expect(sum(β[c] * y[c] - λ[c] * w[c] for c in C), ξ))
+           𝔼(sum(β[c] * y[c] - λ[c] * w[c] for c in C), ξ))
 
 # Define the constraints
 @constraint(model, capacity, sum(x[c] for c in C) <= xbar)
@@ -152,7 +152,7 @@ resolve our `InfiniteOpt` model using ``\epsilon = 0.95``:
 @infinite_variable(model, q(ξ) >= 0)
 
 # Redefine the objective
-@objective(model, Min, sum(α[c] * x[c] for c in C) + t + 1 \ (1 - 0.95) * expect(q, ξ))
+@objective(model, Min, sum(α[c] * x[c] for c in C) + t + 1 \ (1 - 0.95) * 𝔼(q, ξ))
 
 # Add the max constraint
 @constraint(model, max, q >= sum(β[c] * y[c] - λ[c] * w[c] for c in C) - t)
@@ -215,14 +215,14 @@ m = InfiniteModel(optimizer_with_attributes(Ipopt.Optimizer, "print_level" => 0)
 @infinite_variable(m, u[1:2](t), start = 0) # thruster input
 
 # Specify the objective
-@objective(m, Min, integral(u[1]^2 + u[2]^2, t))
+@objective(m, Min, ∫(u[1]^2 + u[2]^2, t))
 
 # Set the initial conditions
 @BDconstraint(m, initial_velocity[i = 1:2](t == 0), v[i] == 0)
 
 # Define the point physics
-@constraint(m, [i = 1:2], deriv(x[i], t) == v[i])
-@constraint(m, [i = 1:2], deriv(v[i], t) == u[i])
+@constraint(m, [i = 1:2], ∂(x[i], t) == v[i])
+@constraint(m, [i = 1:2], ∂(v[i], t) == u[i])
 
 # Hit all the waypoints
 @BDconstraint(m, [i = 1:2, j = eachindex(tw)](t == tw[j]), x[i] == xw[i, j])

--- a/docs/src/extensions.md
+++ b/docs/src/extensions.md
@@ -368,7 +368,7 @@ independent in order to throw a warning when needed.
 We create measure for `f` and `g` using the `uniform_grid` method
 ```jldoctest measure_eval
 julia> f_int = integral(f, t, num_supports = 6, eval_method = UnifGrid)
-integral{t ∈ [0, 5]}[f(t)]
+∫{t ∈ [0, 5]}[f(t)]
 
 julia> expand(f_int)
 0.8333333333333333 f(0) + 0.8333333333333333 f(1) + 0.8333333333333333 f(2) + 0.8333333333333333 f(3) + 0.8333333333333333 f(4) + 0.8333333333333333 f(5)
@@ -682,7 +682,7 @@ build our `InfiniteModel` as normal, for example:
 print(model)
 
 # output
-Min x + expect{ξ}[y[1](ξ) + y[2](ξ)]
+Min x + 𝔼{ξ}[y[1](ξ) + y[2](ξ)]
 Subject to
  y[1](ξ) ≥ 0.0, ∀ ξ ~ Uniform
  y[2](ξ) ≥ 0.0, ∀ ξ ~ Uniform

--- a/docs/src/guide/constraint.md
+++ b/docs/src/guide/constraint.md
@@ -72,7 +72,7 @@ Named constraints are defined by including a name as part of the second argument
 For example, let's add the constraint ``\int_0^10 g(t) dt == 4``:
 ```jldoctest constrs
 julia> @constraint(model, measure_constr, integral(g, t) == 4)
-measure_constr : integral{t ∈ [0, 10]}[g(t)] = 4.0
+measure_constr : ∫{t ∈ [0, 10]}[g(t)] = 4.0
 ```
 Thus, we added another constraint named `measure_constr` and created a `Julia`
 variable `measure_constr` that contains a reference to that constraint.

--- a/docs/src/guide/constraint.md
+++ b/docs/src/guide/constraint.md
@@ -285,7 +285,7 @@ julia> index(measure_constr) # get the constraint's index
 ConstraintIndex(4)
 
 julia> constraint_object(measure_constr) # get the raw constraint datatype
-ScalarConstraint{GenericAffExpr{Float64,GeneralVariableRef},MathOptInterface.EqualTo{Float64}}(integral{t ∈ [0, 10]}[g(t)], MathOptInterface.EqualTo{Float64}(4.0))
+ScalarConstraint{GenericAffExpr{Float64,GeneralVariableRef},MathOptInterface.EqualTo{Float64}}(∫{t ∈ [0, 10]}[g(t)], MathOptInterface.EqualTo{Float64}(4.0))
 ```
 
 Also, [`constraint_by_name`](@ref JuMP.constraint_by_name(::InfiniteModel, ::String))

--- a/docs/src/guide/derivative.md
+++ b/docs/src/guide/derivative.md
@@ -197,8 +197,8 @@ Notice that no error is thrown (which would have occurred if we called
 same derivative object we defined up above with its alias name `dydt2`. This macro 
 can also tackle complex expressions using the appropriate calculus such as:
 ```jldoctest deriv_basic 
-julia> @deriv(integral(y, ξ) * q, t)
-∂/∂t[integral{ξ ∈ [-1, 1]}[y(t, ξ)]]*q(t) + ∂/∂t[q(t)]*integral{ξ ∈ [-1, 1]}[y(t, ξ)]
+julia> @deriv(∫(y, ξ) * q, t)
+∂/∂t[∫{ξ ∈ [-1, 1]}[y(t, ξ)]]*q(t) + ∂/∂t[q(t)]*∫{ξ ∈ [-1, 1]}[y(t, ξ)]
 ```
 Thus, demonstrating the convenience of using `@deriv`.
 
@@ -525,7 +525,7 @@ julia> all_derivatives(model)
  ∂/∂t[∂/∂t[q(t)]]
  ∂/∂ξ[y(t, ξ)]
  dydt2(t, ξ)
- ∂/∂t[integral{ξ ∈ [-1, 1]}[y(t, ξ)]]
+ ∂/∂t[∫{ξ ∈ [-1, 1]}[y(t, ξ)]]
 ```
 
 ## Modification Methods 

--- a/docs/src/guide/derivative.md
+++ b/docs/src/guide/derivative.md
@@ -45,14 +45,18 @@ julia> d1 = @deriv(y, t)
 julia> d2 = @deriv(y, t, ξ)
 ∂/∂ξ[∂/∂t[y(t, ξ)]]
 
-julia> d3 = @deriv(q, t^2)
+julia> d3 = @∂(q, t^2)
 ∂/∂t[∂/∂t[q(t)]]
 
 julia> d_expr = @deriv(y * q - 2t, t)
 ∂/∂t[y(t, ξ)]*q(t) + ∂/∂t[q(t)]*y(t, ξ) - 2
 ```
 Thus, we can define derivatives in a variety of forms according to the problem at 
-hand. The last example even shows hwo the product rule is correctly applied. 
+hand. The last example even shows how the product rule is correctly applied. 
+
+!!! note 
+    For convenience in making more compact code we provide [`∂`](@ref) and 
+    [`@∂`](@ref) as wrappers for [`deriv`](@ref) and [`@deriv`](@ref), respectively.
 
 Also, notice that the appropriate analytic calculus is applied to infinite 
 parameters. For example, we could also compute:
@@ -173,7 +177,7 @@ dydt2(t, ξ)
 This will also support anonymous definition and multi-dimensional definition,  
 please refer to [`@derivative_variable`](@ref) in the manual for the full details.
 
-Second, for more convenient definition we use [`@deriv`](@ref) as shown in the 
+Second, for more convenient definition we use [`@deriv`](@ref) (or [`@∂`](@ref)) as shown in the 
 Basic Usage section above. Unlike `@derivative_variable` this can handle any 
 `InfiniteOpt` expression as the argument input and will automatically take care of 
 any redundant derivative creation by using the existing derivatives as appropriate. 
@@ -606,7 +610,9 @@ Order   = [:macro, :function]
 ```
 ```@docs
 @deriv
+@∂
 deriv
+∂
 @derivative_variable
 build_derivative
 add_derivative

--- a/docs/src/guide/measure.md
+++ b/docs/src/guide/measure.md
@@ -35,7 +35,7 @@ We can construct a measure to represent this integral using the
 [`integral`](@ref) function
 ```jldoctest meas_basic
 julia> mref1 = integral(y^2 + u^2, t, 2, 8)
-integral{t ∈ [2, 8]}[y(t)² + u(t)²]
+∫{t ∈ [2, 8]}[y(t)² + u(t)²]
 ```
 The four positional arguments of [`integral`](@ref) are the integrand expression, 
 the parameter of integration, the lower bound, and the upper bound, respectively. 
@@ -49,16 +49,17 @@ use quadrature methods for univariate parameters in all `IntervalSet`s by settin
 the keyword argument `eval_method` as `Quadrature`:
 ```jldoctest meas_basic
 julia> mref2 = integral(y^2 + u^2, t, eval_method = Quadrature)
-integral{t ∈ [0, 10]}[y(t)² + u(t)²]
+∫{t ∈ [0, 10]}[y(t)² + u(t)²]
 ```
 
 The `integral` function also allows for specifying the number of points for the
 discretization scheme using the keyword argument `num_supports`. The default
 value of `num_supports` is 10.
 ```jldoctest meas_basic
-julia> mref3 = integral(y^2 + u^2, t, num_supports = 20)
-integral{t ∈ [0, 10]}[y(t)² + u(t)²]
+julia> mref3 = ∫(y^2 + u^2, t, num_supports = 20)
+∫{t ∈ [0, 10]}[y(t)² + u(t)²]
 ```
+Notice here how we used [`∫`](@ref) in place of `integral` as a convenient wrapper.
 
 Two other explicit measure type methods include [`expect`](@ref) for expectations 
 and [`support_sum`](@ref) for summing an expression over the support points of 
@@ -73,14 +74,19 @@ julia> @infinite_parameter(m, ξ in Normal(), num_supports = 100);
 julia> @infinite_variable(m, x(ξ));
 
 julia> expect_x = expect(x^2, ξ)
-expect{ξ}[x(ξ)²]
+𝔼{ξ}[x(ξ)²]
 ```
 
 !!! note
     For integrals, expectations, and support sums involving moderate to large 
     expressions, the macro versions [`@integral`](@ref), [`@expect`](@ref), and 
     [`@support_sum`](@ref) should be used instead of their functional equivalents 
-    for better performance. 
+    for better performance.
+
+!!! note 
+    For convenience in compact representation we can use [`∫`](@ref), [`@∫`](@ref), 
+    [`𝔼`](@ref), and [`@𝔼`](@ref) as wrappers for [`integral`](@ref), 
+    [`@integral`](@ref), [`expect`](@ref), and [`@expect`](@ref), respectively.
 
 Other measure paradigms can be implemented via [`measure`](@ref) as described in 
 the sections further below.
@@ -499,10 +505,15 @@ Order   = [:macro, :function]
 ```
 ```@docs
 InfiniteOpt.MeasureToolbox.@integral
+InfiniteOpt.MeasureToolbox.@∫
 InfiniteOpt.MeasureToolbox.integral(::JuMP.AbstractJuMPScalar,::InfiniteOpt.GeneralVariableRef,::Real,::Real)
 InfiniteOpt.MeasureToolbox.integral(::JuMP.AbstractJuMPScalar,::AbstractArray{InfiniteOpt.GeneralVariableRef},::Union{Real, AbstractArray{<:Real}},::Union{Real, AbstractArray{<:Real}})
+InfiniteOpt.MeasureToolbox.∫(::JuMP.AbstractJuMPScalar,::InfiniteOpt.GeneralVariableRef,::Real,::Real)
+InfiniteOpt.MeasureToolbox.∫(::JuMP.AbstractJuMPScalar,::AbstractArray{InfiniteOpt.GeneralVariableRef},::Union{Real, AbstractArray{<:Real}},::Union{Real, AbstractArray{<:Real}})
 InfiniteOpt.MeasureToolbox.@expect
+InfiniteOpt.MeasureToolbox.@𝔼
 InfiniteOpt.MeasureToolbox.expect
+InfiniteOpt.MeasureToolbox.𝔼
 InfiniteOpt.MeasureToolbox.@support_sum
 InfiniteOpt.MeasureToolbox.support_sum
 InfiniteOpt.MeasureToolbox.uni_integral_defaults

--- a/docs/src/guide/objective.md
+++ b/docs/src/guide/objective.md
@@ -28,8 +28,8 @@ julia> @hold_variable(model, x[1:2])
  x[1]
  x[2]
 
-julia> @objective(model, Min, 0.5x[1] + 0.5x[2] + expect(y^2 - y, ξ))
-0.5 x[1] + 0.5 x[2] + expect{ξ}[y(ξ)² - y(ξ)]
+julia> @objective(model, Min, 0.5x[1] + 0.5x[2] + 𝔼(y^2 - y, ξ))
+0.5 x[1] + 0.5 x[2] + 𝔼{ξ}[y(ξ)² - y(ξ)]
 ```
 Thus, we have defined an objective using `InfiniteOpt`'s straightforward syntax.
 Note that the second argument indicates the objective sense which can be
@@ -38,9 +38,9 @@ The objective function (expression) must be finite containing only hold variable
 point variables, and/or measures. Also, any included measures must fully
 integrate over all the infinite parameters contained in its input function.
 For example, if we define had an infinite variable `z(ξ, t)` then the measure
-`expect(z, ξ)` could not be included since the resulting expression would still
+`𝔼(z, ξ)` could not be included since the resulting expression would still
 be infinite with respect to `t`. However, adding a measure for `t` would result
-in a valid object to add to an objective: `integral(expect(z, ξ), t)`.
+in a valid object to add to an objective: `∫(𝔼(z, ξ), t)`.
 
 Now we can add objectives to our infinite models. For more detailed information,
 please review the information below.  
@@ -63,7 +63,7 @@ julia> objective_sense(model)
 MIN_SENSE::OptimizationSense = 0
 
 julia> objective_function(model)
-0.5 x[1] + 0.5 x[2] + expect{ξ}[y(ξ)² - y(ξ)]
+0.5 x[1] + 0.5 x[2] + 𝔼{ξ}[y(ξ)² - y(ξ)]
 
 julia> objective_function_type(model)
 GenericAffExpr{Float64,GeneralVariableRef}
@@ -86,7 +86,7 @@ example from 0.5 to 0.25:
 julia> set_objective_coefficient(model, x[1], 0.25)
 
 julia> objective_function(model)
-0.25 x[1] + 0.5 x[2] + expect{ξ}[y(ξ)² - y(ξ)]
+0.25 x[1] + 0.5 x[2] + 𝔼{ξ}[y(ξ)² - y(ξ)]
 ```
 
 Now let's consider the modification methods that enable the [`@objective`](@ref)

--- a/docs/src/quick_start.md
+++ b/docs/src/quick_start.md
@@ -152,7 +152,7 @@ Now that the variables and parameters are ready to go, let's define our problem.
 First, we can define the objective using [`@objective`](@ref):
  ```jldoctest quick
 julia> @objective(model, Min, integral(sum(u[i]^2 for i in I), t))
-integral{t ∈ [0, 60]}[u[1](t)² + u[2](t)²]
+∫{t ∈ [0, 60]}[u[1](t)² + u[2](t)²]
 ```
 Notice that we also employ [`integral`](@ref) to define the integral. Note that 
 objectives must evaluate over all included infinite domains. 
@@ -209,7 +209,7 @@ And data, a 4-element Array{InfOptConstraintRef,1}:
  c3[4] : -x[1](t, ξ)² - x[2](t, ξ)² + y[4](ξ) + 2 x[1](t, ξ) + 2 x[2](t, ξ) = 2.0, ∀ t = 60, ξ ~ Normal
 
 julia> @constraint(model, c4, expect(sum(y[w] for w in W), ξ) <= ϵ)
-c4 : expect{ξ}[y[1](ξ) + y[2](ξ) + y[3](ξ) + y[4](ξ)] - ϵ ≤ 0.0
+c4 : 𝔼{ξ}[y[1](ξ) + y[2](ξ) + y[3](ξ) + y[4](ξ)] - ϵ ≤ 0.0
 ```
 Notice we are able to invoke an expectation simply by calling [`expect`](@ref).
 

--- a/src/InfiniteOpt.jl
+++ b/src/InfiniteOpt.jl
@@ -38,7 +38,7 @@ UniIndepMCSampling, Quadrature, GaussHermite, GaussLegendre, GaussLaguerre,
 MultiMCSampling, MultiIndepMCSampling, uni_integral_defaults,
 set_uni_integral_defaults, integral, multi_integral_defaults,
 set_multi_integral_defaults, expect, support_sum, @integral, @expect, @support_sum,
-generate_integral_data
+generate_integral_data, 𝔼, ∫, @𝔼, @∫
 
 # Import more methods
 include("derivatives.jl")
@@ -64,7 +64,8 @@ export AbstractDataObject, InfiniteModel
 export @independent_parameter, @dependent_parameters, @infinite_parameter,
 @finite_parameter, @infinite_variable, @point_variable, @hold_variable,
 @infinite_parameter, @BDconstraint, @set_parameter_bounds, @add_parameter_bounds,
-@measure, @integral, @expect, @support_sum, @deriv, @derivative_variable
+@measure, @integral, @expect, @support_sum, @deriv, @derivative_variable, @∂, @𝔼, 
+@∫
 
 # Export variable types 
 export InfOptVariableType, Infinite, Hold, Point, Deriv
@@ -126,7 +127,7 @@ export Derivative, DerivativeRef
 # Export derivative methods 
 export build_derivative, add_derivative, derivative_argument, operator_parameter,
 deriv, evaluate_derivative, evaluate, evaluate_all_derivatives!, num_derivatives, 
-all_derivatives, derivative_constraints, delete_derivative_constraints
+all_derivatives, derivative_constraints, delete_derivative_constraints, ∂
 
 # Export measure datatypes
 export AbstractMeasureData, DiscreteMeasureData, FunctionalDiscreteMeasureData,
@@ -145,7 +146,7 @@ export Automatic, UniTrapezoid, UniMCSampling, UniIndepMCSampling, Quadrature,
 GaussHermite, GaussLegendre, GaussLaguerre, MultiMCSampling,
 MultiIndepMCSampling, uni_integral_defaults, set_uni_integral_defaults,
 integral, multi_integral_defaults, set_multi_integral_defaults, expect,
-support_sum, generate_integral_data
+support_sum, generate_integral_data, 𝔼, ∫
 
 # Export objective methods
 export objective_has_measures

--- a/src/MeasureToolbox/expectations.jl
+++ b/src/MeasureToolbox/expectations.jl
@@ -53,7 +53,7 @@ julia> @infinite_variable(model, f(x))
 f(x)
 
 julia> meas = expect(f, min_num_supports = 2)
-expect{x}[f(x)]
+𝔼{x}[f(x)]
 
 julia> expand(meas)
 0.5 f(0.6791074260357777) + 0.5 f(0.8284134829000359)
@@ -116,4 +116,32 @@ macro expect(expr, prefs, args...)
     expression = :( JuMP.@expression(InfiniteOpt._Model, $expr) )
     mref = :( expect($expression, $prefs; ($(kw_args...))) )
     return esc(mref)
+end
+
+"""
+    𝔼(expr::JuMP.AbstractJuMPScalar,
+      prefs::Union{GeneralVariableRef, AbstractArray{GeneralVariableRef}};
+      [min_num_supports::Int = DefaultNumSupports]
+      )::GeneralVariableRef)
+
+A convenient wrapper for [`expect`](@ref). The unicode symbol `𝔼` is produced by 
+`\\bbE`.
+"""
+function 𝔼(expr::JuMP.AbstractJuMPScalar,
+    prefs::Union{InfiniteOpt.GeneralVariableRef, AbstractArray{InfiniteOpt.GeneralVariableRef}};
+    min_num_supports::Int = InfiniteOpt.DefaultNumSupports
+    )::InfiniteOpt.GeneralVariableRef
+    return expect(expr, prefs, min_num_supports = min_num_supports)
+end
+
+"""
+    @𝔼(expr::JuMP.AbstractJuMPScalar,
+       prefs::Union{GeneralVariableRef, AbstractArray{GeneralVariableRef};
+       [min_num_supports::Int = DefaultNumSupports])::GeneralVariableRef
+
+A convenient wrapper for [`@expect`](@ref). The unicode symbol `𝔼` is produced by 
+`\\bbE`.
+"""
+macro 𝔼(expr, prefs, args...)
+    return esc(:( @expect($expr, $prefs, $(args...)) ))
 end

--- a/src/MeasureToolbox/integrals.jl
+++ b/src/MeasureToolbox/integrals.jl
@@ -563,7 +563,7 @@ julia> @infinite_variable(model, f(x))
 f(x)
 
 julia> int = integral(f, x)
-integral{x ∈ [0, 1]}[f(x)]
+∫{x ∈ [0, 1]}[f(x)]
 
 julia> expand(int)
 0.2 f(0.8236475079774124) + 0.2 f(0.9103565379264364) + 0.2 f(0.16456579813368521) + 0.2 f(0.17732884646626457) + 0.2 f(0.278880109331201)
@@ -597,6 +597,24 @@ function integral(expr::JuMP.AbstractJuMPScalar,
                                   eval_method; processed_kwargs...)
     # make the measure
     return InfiniteOpt.measure(expr, data, name = "integral")
+end
+
+"""
+    ∫(expr::JuMP.AbstractJuMPScalar,
+      pref::GeneralVariableRef,
+      [lower_bound::Real = NaN,
+      upper_bound::Real = NaN;
+      kwargs...])::GeneralVariableRef
+
+A convenient wrapper for [`integral`](@ref). The `∫` unicode symbol is produced 
+via `\\int`.
+"""
+function ∫(expr::JuMP.AbstractJuMPScalar,
+           pref::InfiniteOpt.GeneralVariableRef,
+           lower_bound::Real = NaN,
+           upper_bound::Real = NaN;
+           kwargs...)::InfiniteOpt.GeneralVariableRef
+    return integral(expr, pref, lower_bound, upper_bound; kwargs...)
 end
 
 ################################################################################
@@ -693,7 +711,7 @@ julia> @infinite_parameter(model, x[1:2] in [0, 1], independent = true);
 julia> @infinite_variable(model, f(x));
 
 julia> int = integral(f, x)
-integral{x ∈ [0, 1]^2}[f(x)]
+∫{x ∈ [0, 1]^2}[f(x)]
 ```
 """
 function integral(expr::JuMP.AbstractJuMPScalar,
@@ -744,6 +762,24 @@ function integral(expr::JuMP.AbstractJuMPScalar,
 end
 
 """
+    ∫(expr::JuMP.AbstractJuMPScalar,
+      prefs::AbstractArray{GeneralVariableRef},
+      [lower_bounds::Union{Real, AbstractArray{<:Real}} = NaN,
+      upper_bounds::Union{Real, AbstractArray{<:Real}} = NaN;
+      kwargs...])::GeneralVariableRef
+
+A convenient wrapper for [`integral`](@ref). The unicode symbol `∫` is produced 
+via `\\int`.
+"""
+function ∫(expr::JuMP.AbstractJuMPScalar,
+           prefs::AbstractArray{InfiniteOpt.GeneralVariableRef},
+           lower_bounds::Union{Real, AbstractArray{<:Real}} = NaN,
+           upper_bounds::Union{Real, AbstractArray{<:Real}} = NaN;
+           kwargs...)::InfiniteOpt.GeneralVariableRef
+    return integral(expr, prefs, lower_bounds, upper_bounds; kwargs...)
+end
+
+"""
     @integral(expr::JuMP.AbstractJuMPScalar,
               prefs::Union{GeneralVariableRef, AbstractArray{GeneralVariableRef}},
               [lower_bounds::Union{Real, AbstractArray{<:Real}} = default_bounds,
@@ -765,6 +801,20 @@ macro integral(expr, prefs, args...)
     expression = :( JuMP.@expression(InfiniteOpt._Model, $expr) )
     mref = :( integral($expression, $prefs, $(extra...); ($(kw_args...))) )
     return esc(mref)
+end
+
+"""
+    @∫(expr::JuMP.AbstractJuMPScalar,
+       prefs::Union{GeneralVariableRef, AbstractArray{GeneralVariableRef}},
+       [lower_bounds::Union{Real, AbstractArray{<:Real}} = default_bounds,
+       upper_bounds::Union{Real, AbstractArray{<:Real}} = default_bounds;
+       kwargs...])::GeneralVariableRef
+
+A convenient wrapper for [`@integral`](@ref). The unicode symbol `∫` is produced 
+via `\\int`.
+"""
+macro ∫(expr, prefs, args...)
+    return esc(:( @integral($expr, $prefs, $(args...)) ))
 end
 
 ################################################################################

--- a/src/derivatives.jl
+++ b/src/derivatives.jl
@@ -410,6 +410,27 @@ macro deriv(expr, args...)
     return esc(code)
 end
 
+"""
+    ∂(expr::JuMP.AbstractJuMPScalar, pref1::GeneralVariableRef[, ....]
+      )::Union{JuMP.AbstractJuMPScalar, Float64}
+
+This serves as a convenient unicode wrapper for [`deriv`](@ref). The `∂` is 
+produced via `\\partial`.
+"""
+function ∂(expr, prefs::GeneralVariableRef...)::Union{JuMP.AbstractJuMPScalar, Float64}
+    return deriv(expr, prefs...)
+end
+
+"""
+    @∂(expr, pref_expr1[, ...])::Union{JuMP.AbstractJuMPScalar, Float64}
+
+This serves as a convenient unicode wrapper for [`@deriv`](@ref). The `∂` is 
+produced via `\\partial`.
+"""
+macro ∂(expr, args...)
+    return esc(:( @deriv($expr, $(args...)) ))
+end
+
 ################################################################################
 #                           PARAMETER REFERENCES
 ################################################################################

--- a/src/measures.jl
+++ b/src/measures.jl
@@ -1218,8 +1218,8 @@ Return the list of all measures added to `model`.
 ```julia-repl
 julia> all_measures(model)
 2-element Array{GeneralVariableRef,1}:
- integral{t ∈ [0, 6]}[w(t, x)]
- expect{x}[w(t, x)]
+ ∫{t ∈ [0, 6]}[w(t, x)]
+ 𝔼{x}[w(t, x)]
 ```
 """
 function all_measures(model::InfiniteModel)::Vector{GeneralVariableRef}
@@ -1242,10 +1242,10 @@ meaning it does not belong to the model or it has already been deleted.
 **Example**
 ```julia-repl
 julia> print(model)
-Min integral{t ∈ [0, 6]}[g(t)] + z
+Min ∫{t ∈ [0, 6]}[g(t)] + z
 Subject to
  z ≥ 0.0
- integral{t ∈ [0, 6]}[g(t)] = 0
+ ∫{t ∈ [0, 6]}[g(t)] = 0
  g(t) + z ≥ 42.0, ∀ t ∈ [0, 6]
  g(0.5) = 0
 

--- a/src/show.jl
+++ b/src/show.jl
@@ -9,6 +9,10 @@ function _infopt_math_symbol(::Type{JuMP.REPLMode}, name::Symbol)::String
         return "~"
     elseif name == :partial 
         return Sys.iswindows() ? "d" : "∂"
+    elseif name == :expect 
+        return Sys.iswindows() ? "E" : "𝔼"
+    elseif name == :integral 
+        return Sys.iswindows() ? "integral" : "∫"
     else
         return JuMP._math_symbol(JuMP.REPLMode, name)
     end
@@ -26,6 +30,10 @@ function _infopt_math_symbol(::Type{JuMP.IJuliaMode}, name::Symbol)::String
         return "\\left["
     elseif name == :close_rng 
         return "\\right]"
+    elseif name == :expect 
+        return "\\mathbb{E}"
+    elseif name == :integral 
+        return "\\int"
     else
         return JuMP._math_symbol(JuMP.IJuliaMode, name)
     end
@@ -202,11 +210,17 @@ function measure_data_string(print_mode, data::AbstractMeasureData)::String
 end
 
 # Make strings to represent measures in REPLMode
-function variable_string(::Type{JuMP.REPLMode}, mref::MeasureRef)::String
+function variable_string(m::Type{JuMP.REPLMode}, mref::MeasureRef)::String
     data = measure_data(mref)
-    data_str = measure_data_string(JuMP.REPLMode, data)
-    func_str = JuMP.function_string(JuMP.REPLMode, measure_function(mref))
-    return string(JuMP.name(mref), "{", data_str, "}[", func_str, "]")
+    data_str = measure_data_string(m, data)
+    func_str = JuMP.function_string(m, measure_function(mref))
+    name = JuMP.name(mref)
+    if name == "integral"
+        name = _infopt_math_symbol(m, :integral)
+    elseif name == "expect"
+        name = _infopt_math_symbol(m, :expect)
+    end
+    return string(name, "{", data_str, "}[", func_str, "]")
 end
 
 # Make strings to represent measures in IJuliaMode

--- a/src/variable_basics.jl
+++ b/src/variable_basics.jl
@@ -1266,7 +1266,7 @@ changes are made to the affected variables in the meantime.
 julia> undo_relax = relax_integrality(model);
 
 julia> print(model)
-Min x + integral{t ∈ [0, 10]}(y(t))
+Min x + ∫{t ∈ [0, 10]}(y(t))
 Subject to
  x ≥ 0.0
  y(t) ≥ 1.0
@@ -1276,7 +1276,7 @@ Subject to
 julia> undo_relax()
 
 julia> print(model)
-Min x + integral{t ∈ [0, 10]}(y(t))
+Min x + ∫{t ∈ [0, 10]}(y(t))
 Subject to
  y(t) ≥ 1.0
  y(t) ≤ 10.0

--- a/test/MeasureToolbox/expectations.jl
+++ b/test/MeasureToolbox/expectations.jl
@@ -34,6 +34,7 @@ end
            "dependent parameters."
     @test_logs (:warn, warn) expect(inf, xi[1], min_num_supports = 3)
     @test !InfiniteOpt._is_expect(InfiniteOpt._core_variable_object(expect(inf, y)).data)
+    @test 𝔼(inf, x) isa GeneralVariableRef
 end
 
 @testset "Macro" begin
@@ -46,4 +47,5 @@ end
     @test InfiniteOpt._index_type(@expect(inf, xi, min_num_supports = 20)) == MeasureIndex
     @test_macro_throws ErrorException @expect(inf, x, 1)
     @test_macro_throws ErrorException @expect(inf, x, bob = 35)
+    @test @𝔼(inf, x) isa GeneralVariableRef
 end

--- a/test/MeasureToolbox/integrals.jl
+++ b/test/MeasureToolbox/integrals.jl
@@ -128,6 +128,13 @@ end
         @test_throws ErrorException integral(inf1, t, 3, 1)
         @test name(integral(inf1, t)) == "integral"
     end
+    @testset "∫" begin
+        @test InfiniteOpt._index_type(∫(inf1, t)) == MeasureIndex
+        @test_throws ErrorException ∫(inf1, t, -1, 1)
+        @test_throws ErrorException ∫(inf1, t, 9, 11)
+        @test_throws ErrorException ∫(inf1, t, 3, 1)
+        @test name(∫(inf1, t)) == "integral"
+    end
 end
 
 @testset "Multivariate Integrals" begin
@@ -159,6 +166,17 @@ end
         @test_throws ErrorException integral(inf1, x, 9, 11)
         @test name(integral(inf1, x)) == "integral"
     end
+    @testset "∫" begin
+        @test InfiniteOpt._index_type(∫(inf1, x)) == MeasureIndex
+        @test InfiniteOpt._index_type(∫(inf2, xi)) == MeasureIndex
+        @test InfiniteOpt._index_type(∫(inf1, x, 1, 2)) == MeasureIndex
+        @test InfiniteOpt._index_type(∫(inf2, xi, 1, 2)) == MeasureIndex
+        @test_throws ErrorException ∫(inf3, y, [0, 0], [1, 1])
+        @test_throws ErrorException ∫(inf1, x, 3, 1)
+        @test_throws ErrorException ∫(inf1, x, -1, 1)
+        @test_throws ErrorException ∫(inf1, x, 9, 11)
+        @test name(∫(inf1, x)) == "integral"
+    end
 end
 
 @testset "Macro" begin
@@ -174,5 +192,13 @@ end
         @test InfiniteOpt._index_type(@integral(inf1, t, 3, 7)) == MeasureIndex
         @test InfiniteOpt._index_type(@integral(inf2, x, [0, 2], [3, 5])) == MeasureIndex
         @test_macro_throws ErrorException @integral(inf1, t, 1)
+    end
+    @testset "@∫" begin
+        @test InfiniteOpt._index_type(@∫(inf1, t)) == MeasureIndex
+        @test InfiniteOpt._index_type(@∫(inf2, x)) == MeasureIndex
+        @test InfiniteOpt._index_type(@∫(inf2, t)) == MeasureIndex
+        @test InfiniteOpt._index_type(@∫(inf1, t, 3, 7)) == MeasureIndex
+        @test InfiniteOpt._index_type(@∫(inf2, x, [0, 2], [3, 5])) == MeasureIndex
+        @test_macro_throws ErrorException @∫(inf1, t, 1)
     end
 end

--- a/test/derivatives.jl
+++ b/test/derivatives.jl
@@ -391,6 +391,20 @@ end
         @test deriv(pref^2, pref, pref, pref) == 0
         @test deriv(42, pref, pref) == 0
     end
+    # test "∂"
+    @testset "∂" begin
+        # test errors
+        @test_throws ErrorException ∂(x, pref, fin)
+        @test_throws ErrorException ∂(x)
+        # test normal 
+        gvref = GeneralVariableRef(m, 1, DerivativeIndex)
+        @test ∂(x, pref) == gvref 
+        @test ∂(pref, pref) == 1 
+        @test ∂(x^2 + pref, pref) == 2 * gvref * x + 1
+        @test ∂(pref^2, pref, pref) == 2
+        @test ∂(pref^2, pref, pref, pref) == 0
+        @test ∂(42, pref, pref) == 0
+    end
     # test "@deriv"
     @testset "@deriv" begin
         # test errors
@@ -416,6 +430,22 @@ end
         @test InfiniteOpt._add_data_object(m, data) isa MeasureIndex
         mref = GeneralVariableRef(m, 1, MeasureIndex)
         @test @deriv(mref, prefs[2]) isa GeneralVariableRef
+    end
+    # test "@∂"
+    @testset "@∂" begin
+        # test errors
+        @test_throws ErrorException @∂(x, pref, fin)
+        @test_throws ErrorException @∂(x)
+        # test normal 
+        gvref = GeneralVariableRef(m, 1, DerivativeIndex)
+        gvref2 = GeneralVariableRef(m, 5, DerivativeIndex)
+        @test @∂(x, pref) == gvref 
+        @test @∂(pref, pref) == 1 
+        @test @∂(x^2, pref^2) == 2 * gvref2 * x + 2gvref^2
+        @test @∂(pref^2, pref^2) == 2
+        @test @∂(pref^2, pref^3) == 0
+        @test @∂(42, pref^1) == 0
+        @test @∂(x, pref^2, prefs[2]) isa GeneralVariableRef
     end
 end
 

--- a/test/show.jl
+++ b/test/show.jl
@@ -28,9 +28,13 @@ using JuMP: REPLMode, IJuliaMode
         if Sys.iswindows()
             @test InfiniteOpt._infopt_math_symbol(REPLMode, :intersect) == "and"
             @test InfiniteOpt._infopt_math_symbol(REPLMode, :partial) == "d"
+            @test InfiniteOpt._infopt_math_symbol(REPLMode, :integral) == "integral"
+            @test InfiniteOpt._infopt_math_symbol(REPLMode, :expect) == "E"
         else
             @test InfiniteOpt._infopt_math_symbol(REPLMode, :intersect) == "∩"
             @test InfiniteOpt._infopt_math_symbol(REPLMode, :partial) == "∂"
+            @test InfiniteOpt._infopt_math_symbol(REPLMode, :integral) == "∫"
+            @test InfiniteOpt._infopt_math_symbol(REPLMode, :expect) == "𝔼"
         end
         @test InfiniteOpt._infopt_math_symbol(REPLMode, :times) == "*"
         @test InfiniteOpt._infopt_math_symbol(REPLMode, :prop) == "~"
@@ -43,6 +47,8 @@ using JuMP: REPLMode, IJuliaMode
         @test InfiniteOpt._infopt_math_symbol(IJuliaMode, :partial) == "\\partial"
         @test InfiniteOpt._infopt_math_symbol(IJuliaMode, :open_rng) == "\\left["
         @test InfiniteOpt._infopt_math_symbol(IJuliaMode, :close_rng) == "\\right]"
+        @test InfiniteOpt._infopt_math_symbol(IJuliaMode, :integral) == "\\int"
+        @test InfiniteOpt._infopt_math_symbol(IJuliaMode, :expect) == "\\mathbb{E}"
     end
     # test _plural
     @testset "_plural" begin
@@ -261,14 +267,19 @@ using JuMP: REPLMode, IJuliaMode
         @test InfiniteOpt.variable_string(REPLMode, meas) == str
         str = "\\text{test}_{pars2 " * JuMP._math_symbol(IJuliaMode, :in) * " [0, 1]^2}\\left[y\\right]"
         @test InfiniteOpt.variable_string(IJuliaMode, meas) == str
-        # test measure toolbox special cases for IJulia
+        # test measure toolbox special cases for integrals and expectations
         @infinite_parameter(m, t in [0, 1])
         meas = dispatch_variable_ref(expect(y, t))
         str = "\\mathbb{E}_{t}\\left[y\\right]"
         @test InfiniteOpt.variable_string(IJuliaMode, meas) == str
+        str = InfiniteOpt._infopt_math_symbol(REPLMode, :expect) * "{t}[y]"
+        @test InfiniteOpt.variable_string(REPLMode, meas) == str
         meas = dispatch_variable_ref(integral(y, t))
         str = "\\int_{t " * JuMP._math_symbol(IJuliaMode, :in) * " [0, 1]}ydt"
         @test InfiniteOpt.variable_string(IJuliaMode, meas) == str
+        int = InfiniteOpt._infopt_math_symbol(REPLMode, :integral)
+        str = int * "{t " * JuMP._math_symbol(REPLMode, :in) * " [0, 1]}[y]"
+        @test InfiniteOpt.variable_string(REPLMode, meas) == str
         meas = dispatch_variable_ref(integral(y, par1))
         str = "\\int_{par1 " * JuMP._math_symbol(IJuliaMode, :in) * " [0, 1]}yd(par1)"
         @test InfiniteOpt.variable_string(IJuliaMode, meas) == str


### PR DESCRIPTION
Added `∂`, `∫`, and `𝔼` as wrappers for `deriv`, `integral`, and `expect`, respectively. Wrappers for the more efficient macro variants were also added.