### PR TITLE
Added Quadrature Methods for Integration

### DIFF
--- a/docs/src/guide/measure.md
+++ b/docs/src/guide/measure.md
@@ -46,9 +46,9 @@ be over the entire domain, which is ``[0, 10]`` in this case.
 The `integral` function uses trapezoid rule as the default discretization scheme
 for univariate parameters in finite `IntervalSet`s. In addition, the user can also 
 use quadrature methods for univariate parameters in all `IntervalSet`s by setting
-the keyword argument `eval_method` as `Quadrature`:
+the keyword argument `eval_method` as `Quadrature()`:
 ```jldoctest meas_basic
-julia> mref2 = integral(y^2 + u^2, t, eval_method = Quadrature)
+julia> mref2 = integral(y^2 + u^2, t, eval_method = Quadrature())
 ∫{t ∈ [0, 10]}[y(t)² + u(t)²]
 ```
 
@@ -125,13 +125,13 @@ of the measure. The default value of these keyword arguments can be queried usin
 julia> uni_integral_defaults()
 Dict{Symbol,Any} with 3 entries:
   :num_supports => 10
-  :eval_method  => Automatic
+  :eval_method  => Automatic()
   :weight_func  => default_weight
 
 julia> multi_integral_defaults()
 Dict{Symbol,Any} with 3 entries:
   :num_supports => 10
-  :eval_method  => Automatic
+  :eval_method  => Automatic()
   :weight_func  => default_weight
 ```
 `Automatic` dictates that the integral is created using the default method depending
@@ -274,18 +274,21 @@ Each method is limited on the dimension of parameter and/or the type of set
 that it can apply for. For the details of what each method type means, refer to the corresponding
 docstrings.
 
-| Evaluation Method              | Uni/Multi-Variate? | Set Type                            |
-|:------------------------------:|:------------------:|:-----------------------------------:|
-| [`Automatic`](@ref)            | Both               | Any                                 |
-| [`UniTrapezoid`](@ref)         | Both               | [`IntervalSet`](@ref)               |
-| [`UniMCSampling`](@ref)        | Univariate         | Finite [`IntervalSet`](@ref)        |
-| [`UniIndepMCSampling`](@ref)   | Univariate         | Finite [`IntervalSet`](@ref)        |
-| [`Quadrature`](@ref)           | Univariate         | [`IntervalSet`](@ref)               |
-| [`GaussLegendre`](@ref)        | Univariate         | Finite [`IntervalSet`](@ref)        |
-| [`GaussLaguerre`](@ref)        | Univariate         | Semi-infinite [`IntervalSet`](@ref) |
-| [`GaussHermite`](@ref)         | Univariate         | Infinite [`IntervalSet`](@ref)      |
-| [`MultiMCSampling`](@ref)      | Multivariate       | Finite [`IntervalSet`](@ref)        |
-| [`MultiIndepMCSampling`](@ref) | Multivariate       | Finite [`IntervalSet`](@ref)        |
+| Evaluation Method              | Uni/Multi-Variate? | Set Type                              |
+|:------------------------------:|:------------------:|:-------------------------------------:|
+| [`Automatic()`](@ref)            | Both               | Any                                 |
+| [`UniTrapezoid()`](@ref)         | Both               | [`IntervalSet`](@ref)               |
+| [`UniMCSampling()`](@ref)        | Univariate         | Finite [`IntervalSet`](@ref)        |
+| [`UniIndepMCSampling()`](@ref)   | Univariate         | Finite [`IntervalSet`](@ref)        |
+| [`Quadrature()`](@ref)           | Univariate         | [`IntervalSet`](@ref)               |
+| [`GaussLegendre()`](@ref)        | Univariate         | Finite [`IntervalSet`](@ref)        |
+| [`GaussRadau()`](@ref)           | Univariate         | Finite [`IntervalSet`](@ref)        |
+| [`GaussJacobi()`](@ref)          | Univariate         | Finite [`IntervalSet`](@ref)        |
+| [`GaussLobatto()`](@ref)         | Univariate         | Finite [`IntervalSet`](@ref)        |
+| [`GaussLaguerre()`](@ref)        | Univariate         | Semi-infinite [`IntervalSet`](@ref) |
+| [`GaussHermite()`](@ref)         | Univariate         | Infinite [`IntervalSet`](@ref)      |
+| [`MultiMCSampling()`](@ref)      | Multivariate       | Finite [`IntervalSet`](@ref)        |
+| [`MultiIndepMCSampling()`](@ref) | Multivariate       | Finite [`IntervalSet`](@ref)        |
 
 In summary, we natively support trapezoid rule, Gaussian quadrature methods for univariate parameters,
 and Monte Carlo sampling for both univariate and multivariate parameters.
@@ -490,6 +493,9 @@ InfiniteOpt.MeasureToolbox.UniIndepMCSampling
 InfiniteOpt.MeasureToolbox.Quadrature
 InfiniteOpt.MeasureToolbox.GaussHermite
 InfiniteOpt.MeasureToolbox.GaussLegendre
+InfiniteOpt.MeasureToolbox.GaussRadau
+InfiniteOpt.MeasureToolbox.GaussLobatto
+InfiniteOpt.MeasureToolbox.GaussJacobi
 InfiniteOpt.MeasureToolbox.GaussLaguerre
 InfiniteOpt.MeasureToolbox.AbstractMultivariateMethod
 InfiniteOpt.MeasureToolbox.MultiMCSampling

--- a/src/InfiniteOpt.jl
+++ b/src/InfiniteOpt.jl
@@ -34,7 +34,8 @@ include("measures.jl")
 # Import MeasureToolbox
 include("MeasureToolbox/MeasureToolbox.jl")
 using .MeasureToolbox: Automatic, UniTrapezoid, UniMCSampling,
-UniIndepMCSampling, Quadrature, GaussHermite, GaussLegendre, GaussLaguerre,
+UniIndepMCSampling, Quadrature, GaussHermite, GaussLegendre, GaussRadau, 
+GaussLobatto, GaussJacobi, GaussLaguerre,
 MultiMCSampling, MultiIndepMCSampling, uni_integral_defaults,
 set_uni_integral_defaults, integral, multi_integral_defaults,
 set_multi_integral_defaults, expect, support_sum, @integral, @expect, @support_sum,
@@ -147,7 +148,7 @@ delete_reduced_variable, expand, expand_all_measures!, expand_measure
 
 # Export the measure toolbox functions and datatypes
 export Automatic, UniTrapezoid, UniMCSampling, UniIndepMCSampling, Quadrature,
-GaussHermite, GaussLegendre, GaussLaguerre, MultiMCSampling,
+GaussRadau, GaussHermite, GaussLegendre, GaussRadau, GaussLobatto, GaussJacobi, GaussLaguerre, MultiMCSampling,
 MultiIndepMCSampling, uni_integral_defaults, set_uni_integral_defaults,
 integral, multi_integral_defaults, set_multi_integral_defaults, expect,
 support_sum, generate_integral_data, 𝔼, ∫

--- a/src/InfiniteOpt.jl
+++ b/src/InfiniteOpt.jl
@@ -148,7 +148,7 @@ delete_reduced_variable, expand, expand_all_measures!, expand_measure
 
 # Export the measure toolbox functions and datatypes
 export Automatic, UniTrapezoid, UniMCSampling, UniIndepMCSampling, Quadrature,
-GaussRadau, GaussHermite, GaussLegendre, GaussRadau, GaussLobatto, GaussJacobi, GaussLaguerre, MultiMCSampling,
+GaussHermite, GaussLegendre, GaussRadau, GaussLobatto, GaussJacobi, GaussLaguerre, MultiMCSampling,
 MultiIndepMCSampling, uni_integral_defaults, set_uni_integral_defaults,
 integral, multi_integral_defaults, set_multi_integral_defaults, expect,
 support_sum, generate_integral_data, 𝔼, ∫

--- a/src/MeasureToolbox/integrals.jl
+++ b/src/MeasureToolbox/integrals.jl
@@ -10,10 +10,10 @@ An abstract type for integral evaluation methods use in combination with
 abstract type AbstractIntegralMethod end
 
 """
-    Automatic() <: AbstractIntegralMethod
+    Automatic <: AbstractIntegralMethod
 
 An integral evaluation type for automically selecting an appropriate integral
-evaluation method.
+evaluation method. Contains no fields.
 """
 struct Automatic <: AbstractIntegralMethod end
 
@@ -25,117 +25,120 @@ An abstract type for integral evaluation methods for 1-dimensional integrals.
 abstract type AbstractUnivariateMethod <: AbstractIntegralMethod end
 
 """
-    UniTrapezoid() <: AbstractUnivariateMethod
+    UniTrapezoid <: AbstractUnivariateMethod
 
 An integral evalution method that uses the trapezoid rule to in combination
 with all parameter supports available when the integral is expanded and/or when
 the infinite model is optimized, whichever comes first. Note this method will
 ignore the `num_supports` keyword argument. Note this is valid only for finite
-integral domains.
+integral domains. Contains no fields.
 """
 struct UniTrapezoid <: AbstractUnivariateMethod end
 
 """
-    UniMCSampling() <: AbstractUnivariateMethod
+    UniMCSampling <: AbstractUnivariateMethod
 
 An integral evaluation method that uses uniform Monte Carlo sampling to
 approximate the integral. This variant will add more supports to the model as
 needed to satisfy `num_supports` and it will include all supports with the
 `MCSample` label up till the integral is expanded and/or when
 the infinite model is optimized, whichever comes first. Note this is valid only
-for finite integral domains.
+for finite integral domains. Contains no fields.
 """
 struct UniMCSampling <: AbstractUnivariateMethod end
 
 """
-    UniIndepMCSampling() <: AbstractUnivariateMethod
+    UniIndepMCSampling <: AbstractUnivariateMethod
 
 An integral evaluation method that uses uniform Monte Carlo sampling to
 approximate the integral similar to [`UniMCSampling`](@ref MeasureToolbox.UniMCSampling).
 However, this variant will generate its own set of supports and ignore all other
 supports with the `MCSample` label. Note this is valid only for finite integral
-domains. This is not compatible with individual dependent parameters.
+domains. This is not compatible with individual dependent parameters. Contains no fields.
 """
 struct UniIndepMCSampling <: AbstractUnivariateMethod end
 
 """
-    Quadrature() <: AbstractUnivariateMethod
+    Quadrature <: AbstractUnivariateMethod
 
 A general integral evaluation method that will automatically select the
 appropriate quadrature method to approximate the integral. Please note that this
 will generate a unique set of parameter supports and will ignore existing supports
 when the integral is evaluated and thus should be used with caution. However,
 this method is able to handle infinite and semi-infinite integral domains.
-This is not compatible with individual dependent parameters.
+This is not compatible with individual dependent parameters. Contains no fields.
 """
 struct Quadrature <: AbstractUnivariateMethod end
 
 """
-    GaussHermite() <: AbstractUnivariateMethod
+    GaussHermite <: AbstractUnivariateMethod
 
 An integral evaulation method that uses Gauss-Hermite quadrature to
 evaluate integrals. This is valid for infinite integral domains. Note this will
 generate its own set of supports and will ignore other parameter supports.
-This is not compatible with individual dependent parameters.
+This is not compatible with individual dependent parameters. Contains no fields.
 """
 struct GaussHermite <: AbstractUnivariateMethod end
 
 """
-    GaussLegendre() <: AbstractUnivariateMethod
+    GaussLegendre <: AbstractUnivariateMethod
 
 An integral evaulation method that uses Gauss-Legendre quadrature to
 evaluate integrals. This is valid for finite integral domains. Note this will
 generate its own set of supports and will ignore other parameter supports.
-This is not compatible with individual dependent parameters.
+This is not compatible with individual dependent parameters. Contains no fields.
 """
 struct GaussLegendre <: AbstractUnivariateMethod end
 
 """
-    GaussRadau() <: AbstractUnivariateMethod
+    GaussRadau <: AbstractUnivariateMethod
 
 An integral evaulation method that uses Gauss-Radau quadrature to
 evaluate integrals. This is valid for finite integral domains. Note this will
 generate its own set of supports and will ignore other parameter supports.
-This is not compatible with individual dependent parameters.
+This is not compatible with individual dependent parameters. Contains no fields.
 """
 struct GaussRadau <: AbstractUnivariateMethod end
 
 """
-    GaussLobatto() <: AbstractUnivariateMethod
+    GaussLobatto <: AbstractUnivariateMethod
 
 An integral evaulation method that uses Gauss-Lobatto quadrature to
 evaluate integrals. This is valid for finite integral domains. Note this will
 generate its own set of supports and will ignore other parameter supports.
-This is not compatible with individual dependent parameters.
+This is not compatible with individual dependent parameters. Contains no fields.
 """
-struct GaussLobatto <: AbstractUnivariateMethod 
-# points::Array{Float64} = [0]
-end
+struct GaussLobatto <: AbstractUnivariateMethod end
 
 
 """
-    GaussJacobi(α, β) <: AbstractUnivariateMethod
-    α::Float64
-    β::Float64
+    GaussJacobi <: AbstractUnivariateMethod
 
 An integral evaulation method that uses Gauss-Jacobi quadrature to
 evaluate integrals. This is valid for finite integral domains. This requires the user
 to input the alpha and beta shape parameters for their function. This will then
 generate its own set of supports and will ignore other parameter supports.
 This is not compatible with individual dependent parameters.
+
+**Fields**
+- `α::Float64`: The α Jacobi shape parameter.
+- `β::Float64`: The β Jacobi shape parameter.
 """
 struct GaussJacobi <: AbstractUnivariateMethod
-α::Float64
-β::Float64
+    α::Float64
+    β::Float64
+    function GaussJacobi(α::Real, β::Real)
+        return new(float64(α), float64(β))
+    end
 end
 
 """
-    GaussLaguerre() <: AbstractUnivariateMethod
+    GaussLaguerre <: AbstractUnivariateMethod
 
 An integral evaulation method that uses Gauss-Laguerre quadrature to
 evaluate integrals. This is valid for semi-infinite integral domains. Note this
 will generate its own set of supports and will ignore other parameter supports.
-This is not compatible with individual dependent parameters.
+This is not compatible with individual dependent parameters. Contains no fields.
 """
 struct GaussLaguerre <: AbstractUnivariateMethod end
 
@@ -147,7 +150,7 @@ An abstract type for integral evaluation methods for multi-dimensional integrals
 abstract type AbstractMultivariateMethod <: AbstractIntegralMethod end
 
 """
-    MultiMCSampling() <: AbstractMultivariateMethod
+    MultiMCSampling <: AbstractMultivariateMethod
 
 An integral evaluation method that uses uniform Monte Carlo sampling to
 approximate the integral. This variant will add more supports to the model as
@@ -155,18 +158,18 @@ needed to satisfy `num_supports` and it will include all supports with the
 `MCSample` label up till the integral is expanded and/or when
 the infinite model is optimized, whichever comes first. Note this is valid only
 for finite integral domains. If an array of independent infinite parameters
-is specified, they must use the same amount of supports.
+is specified, they must use the same amount of supports. Contains no fields.
 """
 struct MultiMCSampling <: AbstractMultivariateMethod end
 
 """
-    MultiIndepMCSampling() <: AbstractMultivariateMethod
+    MultiIndepMCSampling <: AbstractMultivariateMethod
 
 An integral evaluation method that uses uniform Monte Carlo sampling to
 approximate the integral similar to [`MultiMCSampling`](@ref MeasureToolbox.MultiMCSampling).
 However, this variant will generate its own set of supports and ignore all other
 supports with the `MCSample` label. Note this is valid only for finite integral
-domains.
+domains. Contains no fields.
 """
 struct MultiIndepMCSampling <: AbstractMultivariateMethod end
 
@@ -614,14 +617,14 @@ Dict{Symbol,Any} with 3 entries:
   :eval_method           => Automatic()
   :weight_func           => default_weight
 
-julia> set_uni_integral_defaults(num_supports = 5, eval_method = Quadrature,
+julia> set_uni_integral_defaults(num_supports = 5, eval_method = Quadrature(),
                                  new_kwarg = true)
 
 julia> uni_integral_defaults()
 Dict{Symbol,Any} with 4 entries:
   :new_kwarg             => true
   :num_supports          => 5
-  :eval_method           => Quadrature
+  :eval_method           => Quadrature()
   :weight_func           => default_weight
 ```
 """
@@ -648,8 +651,8 @@ in accordance with the keyword arugment `eval_method` that is then used with
 `expr` is not just a single variable reference. Errors for bad bound input.
 
 The keyword arguments are as follows:
-- `eval_method::Type{<:AbstractUnivariateMethod}`: Used to determine the
-    numerical evaluation scheme
+- `eval_method::AbstractUnivariateMethod`: Used to determine the
+    numerical evaluation scheme. Possible choices include:
     - [`Automatic`](@ref MeasureToolbox.Automatic)
     - [`UniTrapezoid`](@ref MeasureToolbox.UniTrapezoid)
     - [`UniMCSampling`](@ref MeasureToolbox.UniMCSampling)
@@ -806,8 +809,8 @@ in accordance with the keyword arugment `eval_method` that is then used with
 and dimensions do not match or the bounds are invalid.
 
 The keyword arguments are as follows:
-- `eval_method::Type{<:AbstractMultivariateMethod}`: Used to determine the
-    numerical evaluation scheme
+- `eval_method::AbstractMultivariateMethod`: Used to determine the
+    numerical evaluation scheme. Possible choices include:
     - [`Automatic`](@ref MeasureToolbox.Automatic)
     - [`MultiMCSampling`](@ref MeasureToolbox.MultiMCSampling)
     - [`MultiIndepMCSampling`](@ref MeasureToolbox.MultiIndepMCSampling)

--- a/src/MeasureToolbox/integrals.jl
+++ b/src/MeasureToolbox/integrals.jl
@@ -10,7 +10,7 @@ An abstract type for integral evaluation methods use in combination with
 abstract type AbstractIntegralMethod end
 
 """
-    Automatic <: AbstractIntegralMethod
+    Automatic() <: AbstractIntegralMethod
 
 An integral evaluation type for automically selecting an appropriate integral
 evaluation method.
@@ -25,7 +25,7 @@ An abstract type for integral evaluation methods for 1-dimensional integrals.
 abstract type AbstractUnivariateMethod <: AbstractIntegralMethod end
 
 """
-    UniTrapezoid <: AbstractUnivariateMethod
+    UniTrapezoid() <: AbstractUnivariateMethod
 
 An integral evalution method that uses the trapezoid rule to in combination
 with all parameter supports available when the integral is expanded and/or when
@@ -36,7 +36,7 @@ integral domains.
 struct UniTrapezoid <: AbstractUnivariateMethod end
 
 """
-    UniMCSampling <: AbstractUnivariateMethod
+    UniMCSampling() <: AbstractUnivariateMethod
 
 An integral evaluation method that uses uniform Monte Carlo sampling to
 approximate the integral. This variant will add more supports to the model as
@@ -48,7 +48,7 @@ for finite integral domains.
 struct UniMCSampling <: AbstractUnivariateMethod end
 
 """
-    UniIndepMCSampling <: AbstractUnivariateMethod
+    UniIndepMCSampling() <: AbstractUnivariateMethod
 
 An integral evaluation method that uses uniform Monte Carlo sampling to
 approximate the integral similar to [`UniMCSampling`](@ref MeasureToolbox.UniMCSampling).
@@ -59,7 +59,7 @@ domains. This is not compatible with individual dependent parameters.
 struct UniIndepMCSampling <: AbstractUnivariateMethod end
 
 """
-    Quadrature <: AbstractUnivariateMethod
+    Quadrature() <: AbstractUnivariateMethod
 
 A general integral evaluation method that will automatically select the
 appropriate quadrature method to approximate the integral. Please note that this
@@ -71,7 +71,7 @@ This is not compatible with individual dependent parameters.
 struct Quadrature <: AbstractUnivariateMethod end
 
 """
-    GaussHermite <: AbstractUnivariateMethod
+    GaussHermite() <: AbstractUnivariateMethod
 
 An integral evaulation method that uses Gauss-Hermite quadrature to
 evaluate integrals. This is valid for infinite integral domains. Note this will
@@ -81,7 +81,7 @@ This is not compatible with individual dependent parameters.
 struct GaussHermite <: AbstractUnivariateMethod end
 
 """
-    GaussLegendre <: AbstractUnivariateMethod
+    GaussLegendre() <: AbstractUnivariateMethod
 
 An integral evaulation method that uses Gauss-Legendre quadrature to
 evaluate integrals. This is valid for finite integral domains. Note this will
@@ -91,7 +91,46 @@ This is not compatible with individual dependent parameters.
 struct GaussLegendre <: AbstractUnivariateMethod end
 
 """
-    GaussLaguerre <: AbstractUnivariateMethod
+    GaussRadau() <: AbstractUnivariateMethod
+
+An integral evaulation method that uses Gauss-Radau quadrature to
+evaluate integrals. This is valid for finite integral domains. Note this will
+generate its own set of supports and will ignore other parameter supports.
+This is not compatible with individual dependent parameters.
+"""
+struct GaussRadau <: AbstractUnivariateMethod end
+
+"""
+    GaussLobatto() <: AbstractUnivariateMethod
+
+An integral evaulation method that uses Gauss-Lobatto quadrature to
+evaluate integrals. This is valid for finite integral domains. Note this will
+generate its own set of supports and will ignore other parameter supports.
+This is not compatible with individual dependent parameters.
+"""
+struct GaussLobatto <: AbstractUnivariateMethod 
+# points::Array{Float64} = [0]
+end
+
+
+"""
+    GaussJacobi(α, β) <: AbstractUnivariateMethod
+    α::Float64
+    β::Float64
+
+An integral evaulation method that uses Gauss-Jacobi quadrature to
+evaluate integrals. This is valid for finite integral domains. This requires the user
+to input the alpha and beta shape parameters for their function. This will then
+generate its own set of supports and will ignore other parameter supports.
+This is not compatible with individual dependent parameters.
+"""
+struct GaussJacobi <: AbstractUnivariateMethod
+α::Float64
+β::Float64
+end
+
+"""
+    GaussLaguerre() <: AbstractUnivariateMethod
 
 An integral evaulation method that uses Gauss-Laguerre quadrature to
 evaluate integrals. This is valid for semi-infinite integral domains. Note this
@@ -108,7 +147,7 @@ An abstract type for integral evaluation methods for multi-dimensional integrals
 abstract type AbstractMultivariateMethod <: AbstractIntegralMethod end
 
 """
-    MultiMCSampling <: AbstractMultivariateMethod
+    MultiMCSampling() <: AbstractMultivariateMethod
 
 An integral evaluation method that uses uniform Monte Carlo sampling to
 approximate the integral. This variant will add more supports to the model as
@@ -121,7 +160,7 @@ is specified, they must use the same amount of supports.
 struct MultiMCSampling <: AbstractMultivariateMethod end
 
 """
-    MultiIndepMCSampling <: AbstractMultivariateMethod
+    MultiIndepMCSampling() <: AbstractMultivariateMethod
 
 An integral evaluation method that uses uniform Monte Carlo sampling to
 approximate the integral similar to [`MultiMCSampling`](@ref MeasureToolbox.MultiMCSampling).
@@ -166,18 +205,18 @@ end
 function generate_integral_data(pref::InfiniteOpt.GeneralVariableRef,
     lower_bound::Real,
     upper_bound::Real,
-    method::Type{Automatic};
+    method::Automatic;
     num_supports::Int = InfiniteOpt.DefaultNumSupports,
     weight_func::Function = InfiniteOpt.default_weight
     )::InfiniteOpt.AbstractMeasureData
     is_depend = InfiniteOpt._index_type(pref) == DependentParameterIndex
     inf_bound_num = (lower_bound == -Inf) + (upper_bound == Inf)
     if inf_bound_num == 0 # finite interval
-        method = UniTrapezoid
+        method = UniTrapezoid()
     elseif inf_bound_num == 1 && !is_depend # semi-infinite interval
-        method = GaussLaguerre
+        method = GaussLaguerre()
     elseif inf_bound_num == 2 && !is_depend # infinite interval
-        method = GaussHermite
+        method = GaussHermite()
     else
         error("Cannot generate measure data for individual dependent parameters " *
               "with infinite or semi-infinite domains.")
@@ -210,7 +249,7 @@ end
 function generate_integral_data(pref::InfiniteOpt.GeneralVariableRef,
                                 lower_bound::Real,
                                 upper_bound::Real,
-                                method::Type{UniTrapezoid};
+                                method::UniTrapezoid;
                                 num_supports::Int = InfiniteOpt.DefaultNumSupports,
                                 weight_func::Function = InfiniteOpt.default_weight)
     return InfiniteOpt.FunctionalDiscreteMeasureData(pref, _trapezoid_coeff, 0,
@@ -232,17 +271,17 @@ end
 function generate_integral_data(pref::InfiniteOpt.GeneralVariableRef,
                                 lower_bound::Real,
                                 upper_bound::Real,
-                                method::Type{Quadrature};
+                                method::Quadrature;
                                 num_supports::Int = InfiniteOpt.DefaultNumSupports,
                                 weight_func::Function = InfiniteOpt.default_weight)
     _ensure_independent_param(pref, method)
     inf_bound_num = (lower_bound == -Inf) + (upper_bound == Inf)
     if inf_bound_num == 0 # finite interval
-        method = GaussLegendre
+        method = GaussLegendre()
     elseif inf_bound_num == 1 # semi-infinite interval
-        method = GaussLaguerre
+        method = GaussLaguerre()
     else # infinite interval
-        method = GaussHermite
+        method = GaussHermite()
     end
     return generate_integral_data(pref, lower_bound, upper_bound, method,
                                   num_supports = num_supports, weight_func = weight_func)
@@ -252,14 +291,14 @@ end
 function generate_integral_data(pref::InfiniteOpt.GeneralVariableRef,
                                 lower_bound::Real,
                                 upper_bound::Real,
-                                method::Type{GaussLegendre};
+                                method::GaussLegendre;
                                 num_supports::Int = InfiniteOpt.DefaultNumSupports,
                                 weight_func::Function = InfiniteOpt.default_weight)
     _ensure_independent_param(pref, method)
     if lower_bound == -Inf || upper_bound == Inf
         @warn("Gauss Legendre quadrature can only be applied on finite intervals, " *
               "switching to an appropriate method.")
-        return generate_integral_data(pref, lower_bound, upper_bound, Quadrature,
+        return generate_integral_data(pref, lower_bound, upper_bound, Quadrature(),
                                       num_supports = num_supports,
                                       weight_func = weight_func)
     end
@@ -272,11 +311,83 @@ function generate_integral_data(pref::InfiniteOpt.GeneralVariableRef,
                                            false)
 end
 
+# Single pref Gauss-Radau
+function generate_integral_data(pref::InfiniteOpt.GeneralVariableRef,
+                                lower_bound::Real,
+                                upper_bound::Real,
+                                method::GaussRadau;
+                                num_supports::Int = InfiniteOpt.DefaultNumSupports,
+                                weight_func::Function = InfiniteOpt.default_weight)
+    _ensure_independent_param(pref, method)
+    if lower_bound == -Inf || upper_bound == Inf
+        @warn("Gauss Radau quadrature can only be applied on finite intervals, " *
+            "switching to an appropriate method.")
+    return generate_integral_data(pref, lower_bound, upper_bound, Quadrature(),
+                                        num_supports = num_supports,
+                                        weight_func = weight_func)
+    end
+    (supports, coeffs) = FastGaussQuadrature.gaussradau(num_supports)
+    supports = (upper_bound - lower_bound) / 2 * supports .+ (upper_bound + lower_bound) / 2
+    coeffs = (upper_bound - lower_bound) / 2 * coeffs
+    return InfiniteOpt.DiscreteMeasureData(pref, coeffs, supports, 
+                                            InfiniteOpt.generate_unique_label(),
+                                            weight_func, lower_bound, upper_bound,
+                                            false)
+end
+
+# Single pref Gauss-Lobatto
+function generate_integral_data(pref::InfiniteOpt.GeneralVariableRef,
+                                lower_bound::Real,
+                                upper_bound::Real,
+                                method::GaussLobatto;
+                                num_supports::Int = InfiniteOpt.DefaultNumSupports,
+                                weight_func::Function = InfiniteOpt.default_weight)
+    _ensure_independent_param(pref, method)
+    if lower_bound == -Inf || upper_bound == Inf
+        @warn("Gauss Lobatto quadrature can only be applied on finite intervals, " *
+            "switching to an appropriate method.")
+    return generate_integral_data(pref, lower_bound, upper_bound, Quadrature(),
+                                        num_supports = num_supports,
+                                        weight_func = weight_func)
+    end
+    (supports, coeffs) = FastGaussQuadrature.gausslobatto(num_supports)
+    supports = (upper_bound - lower_bound) / 2 * supports .+ (upper_bound + lower_bound) / 2
+    coeffs = (upper_bound - lower_bound) / 2 * coeffs
+return InfiniteOpt.DiscreteMeasureData(pref, coeffs, supports, 
+                                            InfiniteOpt.generate_unique_label(),
+                                            weight_func, lower_bound, upper_bound,
+                                            false)
+end
+
+# Single pref Gauss-Jacobi
+function generate_integral_data(pref::InfiniteOpt.GeneralVariableRef,
+                                lower_bound::Real,
+                                upper_bound::Real,
+                                method::GaussJacobi;
+                                num_supports::Int = InfiniteOpt.DefaultNumSupports,
+                                weight_func::Function = InfiniteOpt.default_weight)
+    _ensure_independent_param(pref, method)
+    if lower_bound == -Inf || upper_bound == Inf
+        @warn("Gauss Jacobi quadrature can only be applied on finite intervals, " *
+            "switching to an appropriate method.")
+    return generate_integral_data(pref, lower_bound, upper_bound, Quadrature(),
+                                        num_supports = num_supports,
+                                        weight_func = weight_func)
+    end
+    (supports, coeffs) = FastGaussQuadrature.gaussjacobi(num_supports, method.α, method.β)
+    supports = (upper_bound - lower_bound) / 2 * supports .+ (upper_bound + lower_bound) / 2
+    coeffs = (upper_bound - lower_bound) / 2 * coeffs
+return InfiniteOpt.DiscreteMeasureData(pref, coeffs, supports, 
+                                            InfiniteOpt.generate_unique_label(),
+                                            weight_func, lower_bound, upper_bound,
+                                            false)
+end
+
 # Single pref Gauss-Laguerre
 function generate_integral_data(pref::InfiniteOpt.GeneralVariableRef,
                                 lower_bound::Real,
                                 upper_bound::Real,
-                                method::Type{GaussLaguerre};
+                                method::GaussLaguerre;
                                 num_supports::Int = InfiniteOpt.DefaultNumSupports,
                                 weight_func::Function = InfiniteOpt.default_weight)
     _ensure_independent_param(pref, method)
@@ -284,7 +395,7 @@ function generate_integral_data(pref::InfiniteOpt.GeneralVariableRef,
         if lower_bound == -Inf
             @warn("Gauss Laguerre quadrature can only be applied on semi-infinite intervals, " *
                   "switching to an appropriate method.")
-            return generate_integral_data(pref, lower_bound, upper_bound, GaussHermite,
+            return generate_integral_data(pref, lower_bound, upper_bound, GaussHermite(),
                                           num_supports = num_supports,
                                           weight_func = weight_func)
         end
@@ -298,7 +409,7 @@ function generate_integral_data(pref::InfiniteOpt.GeneralVariableRef,
     else
         @warn("Gauss Laguerre quadrature can only be applied on semi-infinite intervals, " *
               "switching to an appropriate method.")
-        return generate_integral_data(pref, lower_bound, upper_bound, GaussLegendre,
+        return generate_integral_data(pref, lower_bound, upper_bound, GaussLegendre(),
                                       num_supports = num_supports,
                                       weight_func = weight_func)
     end
@@ -313,14 +424,14 @@ end
 function generate_integral_data(pref::InfiniteOpt.GeneralVariableRef,
                                 lower_bound::Real,
                                 upper_bound::Real,
-                                method::Type{GaussHermite};
+                                method::GaussHermite;
                                 num_supports::Int = InfiniteOpt.DefaultNumSupports,
                                 weight_func::Function = InfiniteOpt.default_weight)
     _ensure_independent_param(pref, method)
     if lower_bound != -Inf || upper_bound != Inf
         @warn("Gauss Hermite quadrature can only be applied on infinite intervals, " *
               "switching to an appropriate method.")
-        return generate_integral_data(pref, lower_bound, upper_bound, Quadrature,
+        return generate_integral_data(pref, lower_bound, upper_bound, Quadrature(),
                                       num_supports = num_supports,
                                       weight_func = weight_func)
     end
@@ -336,7 +447,7 @@ end
 function generate_integral_data(pref::InfiniteOpt.GeneralVariableRef,
                                 lower_bound::Real,
                                 upper_bound::Real,
-                                method::Type{UniMCSampling};
+                                method::UniMCSampling;
                                 num_supports::Int = InfiniteOpt.DefaultNumSupports,
                                 weight_func::Function = InfiniteOpt.default_weight)
     # check and process the arguments
@@ -366,7 +477,7 @@ end
 function generate_integral_data(pref::InfiniteOpt.GeneralVariableRef,
                                 lower_bound::Real,
                                 upper_bound::Real,
-                                method::Type{UniIndepMCSampling};
+                                method::UniIndepMCSampling;
                                 num_supports::Int = InfiniteOpt.DefaultNumSupports,
                                 weight_func::Function = InfiniteOpt.default_weight)
     _ensure_independent_param(pref, method)
@@ -389,12 +500,12 @@ end
 function generate_integral_data(prefs::Vector{InfiniteOpt.GeneralVariableRef},
     lower_bounds::Vector{<:Real},
     upper_bounds::Vector{<:Real},
-    method::Type{Automatic};
+    method::Automatic;
     num_supports::Int = InfiniteOpt.DefaultNumSupports,
     weight_func::Function = InfiniteOpt.default_weight
     )::InfiniteOpt.AbstractMeasureData
     return generate_integral_data(prefs, lower_bounds, upper_bounds,
-                                  MultiMCSampling, num_supports = num_supports,
+                                  MultiMCSampling(), num_supports = num_supports,
                                   weight_func = weight_func)
 end
 
@@ -402,7 +513,7 @@ end
 function generate_integral_data(prefs::Vector{InfiniteOpt.GeneralVariableRef},
     lower_bounds::Vector{<:Real},
     upper_bounds::Vector{<:Real},
-    method::Type{MultiMCSampling};
+    method::MultiMCSampling;
     num_supports::Int = InfiniteOpt.DefaultNumSupports,
     weight_func::Function = InfiniteOpt.default_weight
     )::InfiniteOpt.AbstractMeasureData
@@ -441,7 +552,7 @@ end
 function generate_integral_data(prefs::Vector{InfiniteOpt.GeneralVariableRef},
     lower_bounds::Vector{<:Real},
     upper_bounds::Vector{<:Real},
-    method::Type{MultiIndepMCSampling};
+    method::MultiIndepMCSampling;
     num_supports::Int = InfiniteOpt.DefaultNumSupports,
     weight_func::Function = InfiniteOpt.default_weight
     )::InfiniteOpt.AbstractMeasureData
@@ -467,7 +578,7 @@ end
 #                           UNIVARIATE INTEGRALS
 ################################################################################
 # Define default keyword arguments for 1-D integrals
-const UniIntegralDefaults = Dict(:eval_method => Automatic,
+const UniIntegralDefaults = Dict(:eval_method => Automatic(),
                                  :num_supports => InfiniteOpt.DefaultNumSupports,
                                  :weight_func => InfiniteOpt.default_weight)
 
@@ -480,7 +591,7 @@ Get the default keyword argument values for defining one-dimensional integrals.
 julia> uni_integral_defaults()
 Dict{Symbol,Any} with 3 entries:
   :num_supports          => 10
-  :eval_method           => Automatic
+  :eval_method           => Automatic()
   :weight_func           => default_weight
 ```
 """
@@ -500,7 +611,7 @@ with a single infinite parameter.
 julia> uni_integral_defaults()
 Dict{Symbol,Any} with 3 entries:
   :num_supports          => 10
-  :eval_method           => Automatic
+  :eval_method           => Automatic()
   :weight_func           => default_weight
 
 julia> set_uni_integral_defaults(num_supports = 5, eval_method = Quadrature,
@@ -546,7 +657,10 @@ The keyword arguments are as follows:
     - [`Quadrature`](@ref MeasureToolbox.Quadrature)
     - [`GaussHermite`](@ref MeasureToolbox.GaussHermite)
     - [`GaussLegendre`](@ref MeasureToolbox.GaussLegendre)
-    - [`GaussLaguerre`](@ref MeasureToolbox.GaussLaguerre)
+    - [`GaussLageurre`](@ref MeasureToolbox.GaussLaguerre)
+    - [`GaussLobatto`](@ref MeasureToolbox.GaussLobatto)
+    - [`GaussRadau`](@ref MeasureToolbox.GaussRadau)
+    - [`GaussJacobi`](@ref MeasureToolbox.GaussJacobi)
 - `num_supports`: The minimum number of supports to be generated (if used by
     `eval_method`)
 - `weight_func`: ``w(p)`` above with parameter value inputs and scalar output
@@ -621,7 +735,7 @@ end
 #                            MULTIVARIATE INTEGRALS
 ################################################################################
 # Define default keyword arguments for multi-D integrals
-const MultiIntegralDefaults = Dict(:eval_method => Automatic,
+const MultiIntegralDefaults = Dict(:eval_method => Automatic(),
                                    :num_supports => InfiniteOpt.DefaultNumSupports,
                                    :weight_func => InfiniteOpt.default_weight)
 
@@ -634,7 +748,7 @@ Get the default keyword argument values for defining multi-dimensional integrals
 julia> multi_integral_defaults()
 Dict{Symbol,Any} with 3 entries:
   :num_supports          => 10
-  :eval_method           => Automatic
+  :eval_method           => Automatic()
   :weight_func           => default_weight
 ```
 """
@@ -654,7 +768,7 @@ with an array of infinite parameters.
 julia> multi_integral_defaults()
 Dict{Symbol,Any} with 3 entries:
   :num_supports          => 10
-  :eval_method           => Automatic
+  :eval_method           => Automatic()
   :weight_func           => default_weight
 
 julia> set_multi_integral_defaults(num_supports = 5, new_kwarg = true)
@@ -663,7 +777,7 @@ julia> multi_integral_defaults()
 Dict{Symbol,Any} with 4 entries:
   :new_kwarg             => true
   :num_supports          => 5
-  :eval_method           => Automatic
+  :eval_method           => Automatic()
   :weight_func           => default_weight
 ```
 """
@@ -842,7 +956,7 @@ transform function. The default transform function is
 
 **Example**
 ```jldoctest; setup = :(using InfiniteOpt)
-julia> (supps, coeffs) = infinite_transform(-Inf, Inf, 5, sub_method = gauss_legendre)
+julia> (supps, coeffs) = infinite_transform(-Inf, Inf, 5, sub_method = gauss_legendre())
 ([-5.06704059565454, -0.7583532171678754, 0.0, 0.7583532171678754, 5.06704059565454], [13.490960583398396, 1.2245949721571516, 0.5688888888888889, 1.2245949721571516, 13.490960583398396])
 ```
 """

--- a/src/MeasureToolbox/integrals.jl
+++ b/src/MeasureToolbox/integrals.jl
@@ -128,7 +128,7 @@ struct GaussJacobi <: AbstractUnivariateMethod
     α::Float64
     β::Float64
     function GaussJacobi(α::Real, β::Real)
-        return new(float64(α), float64(β))
+        return new(Float64(α), Float64(β))
     end
 end
 

--- a/test/MeasureToolbox/integrals.jl
+++ b/test/MeasureToolbox/integrals.jl
@@ -9,74 +9,98 @@
     end
     # test generate_integral_data (trapezoid)
     @testset "generate_integral_data (trapezoid)" begin
-        @test generate_integral_data(t, 0, 1, UniTrapezoid) ==
+        @test generate_integral_data(t, 0, 1, UniTrapezoid()) ==
                     FunctionalDiscreteMeasureData(t, IOMT._trapezoid_coeff, 0, All, InfiniteOpt.default_weight, 0, 1, false)
     end
     # test _ensure_independent_param
     @testset "_ensure_independent_param" begin
-        @test IOMT._ensure_independent_param(t, Automatic) isa Nothing
-        @test_throws ErrorException IOMT._ensure_independent_param(x[1], Automatic)
+        @test IOMT._ensure_independent_param(t, Automatic()) isa Nothing
+        @test_throws ErrorException IOMT._ensure_independent_param(x[1], Automatic())
     end
     # test generate_integral_data (Gauss-Legendre)
     @testset "generate_integral_data (Gauss-Legendre)" begin
-        @test generate_integral_data(t, 0, 1, GaussLegendre) isa DiscreteMeasureData
+        @test generate_integral_data(t, 0, 1, GaussLegendre()) isa DiscreteMeasureData
+    end
+    # test generate_integral_data (Gauss-Lobatto)
+    @testset "generate_integral_data (Gauss-Lobatoo)" begin
+        @test generate_integral_data(t, 0, 1, GaussLobatto()) isa DiscreteMeasureData
+    end
+    # test generate_integral_data (Gauss-Radau)
+    @testset "generate_integral_data (Gauss-Radau)" begin
+        @test generate_integral_data(t, 0, 1, GaussRadau()) isa DiscreteMeasureData
+    end
+    # test generate_integral_data (Gauss-Jacobi)
+    @testset "generate_integral_data (Gauss-Jacobi)" begin
+        @test generate_integral_data(t, 0, 1, GaussJacobi(5, 4)) isa DiscreteMeasureData
     end
     # test generate_integral_data (Gauss-Laguerre)
     @testset "generate_integral_data (Gauss-Laguerre)" begin
-        @test generate_integral_data(t, -Inf, 0, GaussLaguerre) isa DiscreteMeasureData
-        @test generate_integral_data(t, 0, Inf, GaussLaguerre) isa DiscreteMeasureData
+        @test generate_integral_data(t, -Inf, 0, GaussLaguerre()) isa DiscreteMeasureData
+        @test generate_integral_data(t, 0, Inf, GaussLaguerre()) isa DiscreteMeasureData
     end
     # test generate_integral_data (Gauss-Hermite)
     @testset "generate_integral_data (Gauss-Hermite)" begin
-        @test generate_integral_data(t, -Inf, Inf, GaussHermite) isa DiscreteMeasureData
+        @test generate_integral_data(t, -Inf, Inf, GaussHermite()) isa DiscreteMeasureData
     end
     # test generate_integral_data (Quadrature)
     @testset "generate_integral_data (Quadrature)" begin
-        @test generate_integral_data(t, 0, 1, Quadrature) isa DiscreteMeasureData
-        @test generate_integral_data(t, -Inf, 0, Quadrature) isa DiscreteMeasureData
-        @test generate_integral_data(t, -Inf, Inf, Quadrature) isa DiscreteMeasureData
+        @test generate_integral_data(t, 0, 1, Quadrature()) isa DiscreteMeasureData
+        @test generate_integral_data(t, -Inf, 0, Quadrature()) isa DiscreteMeasureData
+        @test generate_integral_data(t, -Inf, Inf, Quadrature()) isa DiscreteMeasureData
     end
     # test handling of inappropriate quadrature method use
     @testset "generate_integral_data (improper quadrature method usage)" begin
         warn = "Gauss Legendre quadrature can only be applied on finite intervals, " *
                "switching to an appropriate method."
-        @test (@test_logs (:warn, warn) generate_integral_data(t, -Inf, 0, GaussLegendre)) isa DiscreteMeasureData
-        @test (@test_logs (:warn, warn) generate_integral_data(t, -Inf, Inf, GaussLegendre)) isa DiscreteMeasureData
+        @test (@test_logs (:warn, warn) generate_integral_data(t, -Inf, 0, GaussLegendre())) isa DiscreteMeasureData
+        @test (@test_logs (:warn, warn) generate_integral_data(t, -Inf, Inf, GaussLegendre())) isa DiscreteMeasureData
+        warn = "Gauss Lobatto quadrature can only be applied on finite intervals, " *
+               "switching to an appropriate method."
+        @test (@test_logs (:warn, warn) generate_integral_data(t, -Inf, 0, GaussLobatto())) isa DiscreteMeasureData
+        @test (@test_logs (:warn, warn) generate_integral_data(t, -Inf, Inf, GaussLobatto())) isa DiscreteMeasureData
+        warn = "Gauss Radau quadrature can only be applied on finite intervals, " *
+               "switching to an appropriate method."
+        @test (@test_logs (:warn, warn) generate_integral_data(t, -Inf, 0, GaussRadau())) isa DiscreteMeasureData
+        @test (@test_logs (:warn, warn) generate_integral_data(t, -Inf, Inf, GaussRadau())) isa DiscreteMeasureData
+        warn = "Gauss Jacobi quadrature can only be applied on finite intervals, " *
+               "switching to an appropriate method."
+        @test (@test_logs (:warn, warn) generate_integral_data(t, -Inf, 0, GaussJacobi(5, 4))) isa DiscreteMeasureData
+        @test (@test_logs (:warn, warn) generate_integral_data(t, -Inf, Inf, GaussJacobi(5, 4))) isa DiscreteMeasureData
         warn = "Gauss Laguerre quadrature can only be applied on semi-infinite intervals, " *
                "switching to an appropriate method."
-        @test (@test_logs (:warn, warn) generate_integral_data(t, 0, 1, GaussLaguerre)) isa DiscreteMeasureData
-        @test (@test_logs (:warn, warn) generate_integral_data(t, -Inf, Inf, GaussLaguerre)) isa DiscreteMeasureData
+        @test (@test_logs (:warn, warn) generate_integral_data(t, 0, 1, GaussLaguerre())) isa DiscreteMeasureData
+        @test (@test_logs (:warn, warn) generate_integral_data(t, -Inf, Inf, GaussLaguerre())) isa DiscreteMeasureData
         warn = "Gauss Hermite quadrature can only be applied on infinite intervals, " *
                "switching to an appropriate method."
-        @test (@test_logs (:warn, warn) generate_integral_data(t, 0, 1, GaussHermite)) isa DiscreteMeasureData
-        @test (@test_logs (:warn, warn) generate_integral_data(t, -Inf, 0, GaussHermite)) isa DiscreteMeasureData
+        @test (@test_logs (:warn, warn) generate_integral_data(t, 0, 1, GaussHermite())) isa DiscreteMeasureData
+        @test (@test_logs (:warn, warn) generate_integral_data(t, -Inf, 0, GaussHermite())) isa DiscreteMeasureData
     end
     # test generate_integral_data (uniform Monte Carlo)
-    @testset "generate_integral_data (UniMCSampling)" begin
-        @test generate_integral_data(t, 0, 1, UniMCSampling) isa FunctionalDiscreteMeasureData
-        @test_throws ErrorException generate_integral_data(t, -Inf, 0, UniMCSampling)
+    @testset "generate_integral_data (UniMCSampling())" begin
+        @test generate_integral_data(t, 0, 1, UniMCSampling()) isa FunctionalDiscreteMeasureData
+        @test_throws ErrorException generate_integral_data(t, -Inf, 0, UniMCSampling())
         warn = "Cannot specify a nonzero minimum supports for an individual " *
                "dependent parameter. Setting `num_supports = 0`."
-        @test_logs (:warn, warn) generate_integral_data(x[1], 0, 1, UniMCSampling, num_supports = 1)
+        @test_logs (:warn, warn) generate_integral_data(x[1], 0, 1, UniMCSampling(), num_supports = 1)
     end
     # test generate_integral_data (independent Monte Carlo)
-    @testset "generate_integral_data (UniIndepMCSampling)" begin
-        @test generate_integral_data(t, 0, 1, UniIndepMCSampling) isa DiscreteMeasureData
-        @test_throws ErrorException generate_integral_data(t, -Inf, 0, UniIndepMCSampling)
-        @test_throws ErrorException generate_integral_data(t, -Inf, Inf, UniIndepMCSampling)
+    @testset "generate_integral_data (UniIndepMCSampling())" begin
+        @test generate_integral_data(t, 0, 1, UniIndepMCSampling()) isa DiscreteMeasureData
+        @test_throws ErrorException generate_integral_data(t, -Inf, 0, UniIndepMCSampling())
+        @test_throws ErrorException generate_integral_data(t, -Inf, Inf, UniIndepMCSampling())
     end
     # test generate_integral_data (Automatic)
     @testset "generate_integral_data (Automatic)" begin
-        @test generate_integral_data(t, 0, 1, Automatic) isa FunctionalDiscreteMeasureData
-        @test generate_integral_data(t, -Inf, 1, Automatic) isa DiscreteMeasureData
-        @test generate_integral_data(t, -Inf, Inf, Automatic) isa DiscreteMeasureData
-        @test generate_integral_data(x[1], 0, 1, Automatic) isa FunctionalDiscreteMeasureData
-        @test_throws ErrorException generate_integral_data(x[1], -Inf, 0, Automatic)
-        @test_throws ErrorException generate_integral_data(x[1], -Inf, Inf, Automatic)
+        @test generate_integral_data(t, 0, 1, Automatic()) isa FunctionalDiscreteMeasureData
+        @test generate_integral_data(t, -Inf, 1, Automatic()) isa DiscreteMeasureData
+        @test generate_integral_data(t, -Inf, Inf, Automatic()) isa DiscreteMeasureData
+        @test generate_integral_data(x[1], 0, 1, Automatic()) isa FunctionalDiscreteMeasureData
+        @test_throws ErrorException generate_integral_data(x[1], -Inf, 0, Automatic())
+        @test_throws ErrorException generate_integral_data(x[1], -Inf, Inf, Automatic())
     end
     # test fallback
     @testset "generate_integral_data (fallback)" begin
-        @test_throws ErrorException generate_integral_data(x, 1, 2, Quadrature)
+        @test_throws ErrorException generate_integral_data(x, 1, 2, Quadrature())
     end
 end
 
@@ -85,9 +109,9 @@ end
     @infinite_parameter(m, x[1:2] in [-Inf, Inf])
     # test generate_integral_data (MultiMCSampling)
     @testset "generate_integral_data (MultiMCSampling)" begin
-        @test generate_integral_data(x, [0, 0], [1, 1], MultiMCSampling) isa FunctionalDiscreteMeasureData
-        @test_throws ErrorException generate_integral_data(x, [0, 0], [Inf, 1], MultiMCSampling)
-        @test_throws ErrorException generate_integral_data(x, [0, -Inf], [1, 1], MultiMCSampling)
+        @test generate_integral_data(x, [0, 0], [1, 1], MultiMCSampling()) isa FunctionalDiscreteMeasureData
+        @test_throws ErrorException generate_integral_data(x, [0, 0], [Inf, 1], MultiMCSampling())
+        @test_throws ErrorException generate_integral_data(x, [0, -Inf], [1, 1], MultiMCSampling())
     end
     # test _make_multi_mc_supports
     @testset "_make_multi_mc_supports" begin
@@ -97,13 +121,13 @@ end
     end
     # test generate_integral_data (MultiIndepMCSampling)
     @testset "generate_integral_data (MultiIndepMCSampling)" begin
-        @test generate_integral_data(x, [0, 0], [1, 1], MultiIndepMCSampling) isa DiscreteMeasureData
-        @test_throws ErrorException generate_integral_data(x, [0, 0], [Inf, 1], MultiMCSampling)
-        @test_throws ErrorException generate_integral_data(x, [0, -Inf], [1, 1], MultiMCSampling)
+        @test generate_integral_data(x, [0, 0], [1, 1], MultiIndepMCSampling()) isa DiscreteMeasureData
+        @test_throws ErrorException generate_integral_data(x, [0, 0], [Inf, 1], MultiMCSampling())
+        @test_throws ErrorException generate_integral_data(x, [0, -Inf], [1, 1], MultiMCSampling())
     end
     # test generate_integral_data (Automatic)
     @testset "generate_integral_data (Automatic)" begin
-        @test generate_integral_data(x, [0, 0], [1, 1], Automatic) isa FunctionalDiscreteMeasureData
+        @test generate_integral_data(x, [0, 0], [1, 1], Automatic()) isa FunctionalDiscreteMeasureData
     end
 end
 

--- a/test/extensions.jl
+++ b/test/extensions.jl
@@ -37,7 +37,7 @@
     x = m[:x]
     
     # test measures
-    @test @integral(x^2 + par, par, num_supports = 2, eval_method = GaussLegendre) isa GeneralVariableRef
+    @test @integral(x^2 + par, par, num_supports = 2, eval_method = GaussLegendre()) isa GeneralVariableRef
 
     # test constraints
     @test @constraint(m, x + par <= 0) isa InfOptConstraintRef


### PR DESCRIPTION
Added the following Quadrature Methods:
Gauss-Lobatto
Gauss-Radau
Gauss-Jacobi
In addition I changed the syntax of the eval methods in integrals.jl. Previously one would choose Gauss Legendre quadrature by doing eval_method = GaussRadau, however it is now eval_method = GaussRadau()). This is to allow for parameters to get passed to quadrature methods that require additional inputs such as Gauss Jacobi. I also updated all the documentation to reflect this.