### PR TITLE
Much Enhanced Parameter Functions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,7 @@ DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 
 [compat]
 julia = "1"
-JuMP = "~0.21.4"
+JuMP = "~0.21.6"
 FastGaussQuadrature = "^0.3.2, ~0.4"
 Distributions = "~0.19, ~0.20, ~0.21, ~0.22, ~0.23, ~0.24"
 MathOptInterface = "~0.9.16"

--- a/src/InfiniteOpt.jl
+++ b/src/InfiniteOpt.jl
@@ -69,7 +69,7 @@ export @independent_parameter, @dependent_parameters, @infinite_parameter,
 @finite_parameter, @infinite_variable, @point_variable, @finite_variable, 
 @infinite_parameter, @BDconstraint, @set_parameter_bounds, @add_parameter_bounds, 
 @measure, @integral, @expect, @support_sum, @deriv, @derivative_variable, @∂, @𝔼, 
-@∫
+@∫, @parameter_function
 
 # Export variable types 
 export InfOptVariableType, Infinite, Point, Finite, Deriv

--- a/src/datatypes.jl
+++ b/src/datatypes.jl
@@ -659,7 +659,7 @@ end
 #                        PARAMETER FUNCTION OBJECTS
 ################################################################################
 """
-    ParameterFunction{P <: GeneralVariableRef}
+    ParameterFunction{F <: Function, P <: GeneralVariableRef}
 
 A `DataType` for storing known functions of infinite parameters. These equate to arbitrary 
 functions that take support instances of infinite parameters `parameter_refs` in 
@@ -667,19 +667,22 @@ as input and compute a scalar value as output via `func`. These can then can
 incorporated in expressions via [`ParameterFunctionRef`](@ref)s.
 
 **Fields**
--`func::Function`: The function the takes infinite parameters as input and provide 
-                   a scalar number as output.
--`parameter_refs::VectorTuple{P}`: The infinite parameter references that serve as 
+- `func::F`: The function the takes infinite parameters as input and provide a 
+            scalar number as output.
+- `parameter_refs::VectorTuple{P}`: The infinite parameter references that serve as 
                                    inputs to `func`. Their formatting is analagous 
                                    to those of infinite variables. 
 - `parameter_nums::Vector{Int}`: The parameter numbers of `parameter_refs`.
 - `object_nums::Vector{Int}`: The parameter object numbers associated with `parameter_refs`.
+- `default_name::String`: A helper field for storing the default name of the parameter function 
+                          object.
 """
-struct ParameterFunction{P <: JuMP.AbstractVariableRef}
-    func::Function
+struct ParameterFunction{F <: Function, P <: JuMP.AbstractVariableRef}
+    func::F
     parameter_refs::VectorTuple{P}
     object_nums::Vector{Int}
     parameter_nums::Vector{Int}
+    default_name::String
 end
 
 """
@@ -1323,7 +1326,7 @@ function InfiniteModel(; OptimizerModel::Function = TranscriptionModel,
                          MOIUC.CleverDict{FiniteParameterIndex, ScalarParameterData{FiniteParameter}}(),
                          nothing, 0,
                          Union{IndependentParameterIndex, DependentParametersIndex}[],
-                         MOIUC.CleverDict{ParameterFunctionIndex, ParameterFunctionData{ParameterFunction{GeneralVariableRef}}}(),
+                         MOIUC.CleverDict{ParameterFunctionIndex, ParameterFunctionData{<:ParameterFunction}}(),
                          # Variables
                          MOIUC.CleverDict{InfiniteVariableIndex, VariableData{InfiniteVariable{GeneralVariableRef}}}(),
                          MOIUC.CleverDict{SemiInfiniteVariableIndex, VariableData{SemiInfiniteVariable{GeneralVariableRef}}}(),

--- a/src/expressions.jl
+++ b/src/expressions.jl
@@ -1,5 +1,5 @@
 ################################################################################
-#                       INFINITE PARAMETER FUNCTION METHODS
+#                          PARAMETER FUNCTION METHODS
 ################################################################################
 # Extend dispatch_variable_ref
 function dispatch_variable_ref(model::InfiniteModel,
@@ -17,23 +17,23 @@ end
 
 # Extend _data_dictionary (reference based)
 function _data_dictionary(fref::ParameterFunctionRef
-    )::MOIUC.CleverDict{ParameterFunctionIndex, ParameterFunctionData{ParameterFunction{GeneralVariableRef}}}
+    )::MOIUC.CleverDict{ParameterFunctionIndex, ParameterFunctionData{<:ParameterFunction}}
     return JuMP.owner_model(fref).param_functions
 end
 
 # Extend _data_object
 function _data_object(fref::ParameterFunctionRef
-    )::ParameterFunctionData{ParameterFunction{GeneralVariableRef}}
+    )::ParameterFunctionData
   object = get(_data_dictionary(fref), JuMP.index(fref), nothing)
   object === nothing && error("Invalid parameter function reference, cannot find " *
-                        "corresponding object in the model. This is likely " *
-                        "caused by using the reference of a deleted function.")
+                              "corresponding object in the model. This is likely " *
+                              "caused by using the reference of a deleted function.")
   return object
 end
 
 # Extend _core_variable_object
 function _core_variable_object(fref::ParameterFunctionRef
-    )::ParameterFunction{GeneralVariableRef}
+    )::ParameterFunction
     return _data_object(fref).func
 end
 
@@ -47,35 +47,133 @@ function _parameter_numbers(fref::ParameterFunctionRef)::Vector{Int}
     return _core_variable_object(fref).parameter_nums
 end
 
-"""
-    build_parameter_function(_error::Function, func::Function, 
-        parameter_refs::Union{GeneralVariableRef, AbstractArray{<:GeneralVariableRef}, Tuple}
-        )::ParameterFunction{GeneralVariableRef}
+## Helper methods for building parameter functions 
+# Process the default name argument
+function _process_default_name(name::String, func::Function, fargs, fkwargs)::String 
+    return name
+end
+function _process_default_name(name::Nothing, func::Function, fargs::Nothing, 
+                               fkwargs::Nothing)::String
+    return String(nameof(func))
+end
+function _process_default_name(name::Nothing, func::Function, fargs, fkwargs)::String
+    return String(nameof(func)) # TODO do something to consider fargs and fkwargs
+end
 
-Build an [`ParameterFunction`](@ref) object that employs a infinite 
-parameter function `func` that takes instances of the infinite parameter(s) as 
-input. This can ultimately by incorporated into expressions to enable nonlinear 
-infinite parameter behavior and/or incorporate data over infinite domains. Errors 
-if the infinite parameter tuple is formatted incorrectly. The allowed format 
+# Process the parameter function with additional arguments 
+function _process_parameter_func(_error::Function, func::Function, fargs::Nothing, 
+                                 fkwargs::Nothing, prefs)
+    # check the func is valid
+    supp_type = typeof(Tuple(Vector{Float64}(undef, length(prefs)), prefs))
+    if !hasmethod(func, supp_type)
+        _error("Parameter function method `$(func)` is not defined for `$(func)(" * 
+               join(Tuple(prefs), ", ") * ")`. Note that the infinite parameter " * 
+               "arguments `" * join(Tuple(prefs), ", ") * "` are checked via a " * 
+               "numeric support (each parameter is a `Float64`) of the same format.")
+    end         
+    return func
+end
+function _process_parameter_func(_error::Function, func::Function, fargs::Tuple, 
+                                 fkwargs::NamedTuple, prefs)
+    # check the func is valid
+    supp = Tuple(Vector{Float64}(undef, length(prefs)), prefs)
+    if Base.VERSION >= v"1.2.0" && !hasmethod(func, typeof((supp..., fargs...)), keys(fkwargs))
+        _error("Parameter function method `$(func)` is not defined for `$(func)(" * 
+               join(Tuple(prefs), ", ") * ", " * join(fargs, ", ") * "; " * 
+               _kwargs2string(fkwargs) * ")`. Note that the infinite parameter " * 
+               "arguments `" * join(Tuple(prefs), ", ") * "` are checked via a " * 
+               "numeric support (each parameter is a `Float64`) of the same format.")
+    end
+    # make a wrapper function
+    len = size(prefs, 1)
+    return @eval (s::Vararg{Any, $len}) -> $(func)(s..., $(fargs)...; $(fkwargs)...)
+end
+function _process_parameter_func(_error::Function, func::Function, fargs::Nothing, 
+                                 fkwargs::NamedTuple, prefs)
+    # check the func is valid
+    supp_type = typeof(Tuple(Vector{Float64}(undef, length(prefs)), prefs))
+    if Base.VERSION >= v"1.2.0" && !hasmethod(func, supp_type, keys(fkwargs))
+        _error("Parameter function method `$(func)` is not defined for `$(func)(" * 
+               join(Tuple(prefs), ", ") * "; " * _kwargs2string(fkwargs) * ")`. Note " * 
+               "that the infinite parameter arguments `" * join(Tuple(prefs), ", ") * 
+               "` are checked via a numeric support (each parameter is a " * 
+               "`Float64`) of the same format.")
+    end
+    # make a wrapper function
+    len = size(prefs, 1)
+    return @eval (s::Vararg{Any, $len}) -> $(func)(s...; $(fkwargs)...)
+end
+function _process_parameter_func(_error::Function, func::Function, fargs::Tuple, 
+                                 fkwargs::Nothing, prefs)
+    # check the func is valid
+    supp = Tuple(Vector{Float64}(undef, length(prefs)), prefs)
+    if !hasmethod(func, typeof((supp..., fargs...)))
+        _error("Parameter function method `$(func)` is not defined for `$(func)(" * 
+               join(Tuple(prefs), ", ") * ", " * join(fargs, ", ") * ")`. Note " * 
+               "that the infinite parameter arguments `" * join(Tuple(prefs), ", ") * 
+               "` are checked via a numeric support (each parameter is a " * 
+               "`Float64`) of the same format.")
+    end
+    # make a wrapper function
+    len = size(prefs, 1)
+    return @eval (s::Vararg{Any, $len}) -> $(func)(s..., $(fargs)...)
+end
+
+"""
+    build_parameter_function(
+        _error::Function, 
+        func::Function, 
+        parameter_refs::Union{GeneralVariableRef, AbstractArray{<:GeneralVariableRef}, Tuple};
+        [func_args::Union{Tuple, Nothing} = nothing,
+        func_kwargs::Union{NamedTuple, Nothing} = nothing,
+        default_name::Union{String, Nothing} = nothing]
+        )::ParameterFunction
+
+Build an [`ParameterFunction`](@ref) object that employs a parameter function 
+`func` that takes instances of the infinite parameter(s) as input. This can 
+ultimately by incorporated into expressions to enable nonlinear infinite parameter 
+behavior and/or incorporate data over infinite domains.
+
+Here `func` should be of the form:
+```
+func(paramvals..., func_args...; func_kwargs...)::Float64
+```
+where the formatting of `paramvals` is analagous to point variables (and will be 
+based on the tuple of infinite parameter references given in `parameter_refs`), 
+extra positional arguments can be given via `fun_args`, and keyword arguments can 
+be  given via `func_kwargs`. Moreover, `func` must be a function that returns a 
+scalar numeric value. 
+
+Errors if the infinite parameter tuple is formatted incorrectly. The allowed format 
 follows that of infinite variables. Also errors if the function doesn't accept 
 a support realization of the `parameter_refs` as input.
 
 **Example**
 ```julia-repl 
 julia> f = build_parameter_function(error, sin, t)
-ParameterFunction{GeneralVariableRef}(sin, (t,), [1], [1])
+ParameterFunction{typeof(sin),GeneralVariableRef}(sin, (t,), [1], [1], "sin")
 ```
 """
 function build_parameter_function(
     _error::Function, 
     func::Function, 
-    parameter_refs::Union{GeneralVariableRef, AbstractArray{<:GeneralVariableRef}, Tuple}
-    )::ParameterFunction{GeneralVariableRef}
-    # process the parameter reference inputs
+    parameter_refs::Union{GeneralVariableRef, AbstractArray{<:GeneralVariableRef}, Tuple};
+    func_args::Union{Tuple, Nothing} = nothing,
+    func_kwargs::Union{NamedTuple, Nothing} = nothing,
+    default_name::Union{String, Nothing} = nothing,
+    extra_kwargs...
+    )::ParameterFunction
+    # check for unneeded keywords
+    for (kwarg, _) in extra_kwargs
+        _error("Keyword argument $kwarg is not for use with parameter functions.")
+    end
+    # process the parameter reference inputs and check
     prefs = VectorTuple(parameter_refs)
-    # check the arguments
     _check_parameter_tuple(_error, prefs)
-    _check_valid_function(_error, func, prefs)
+    # process the default name 
+    default_name = _process_default_name(default_name, func, func_args, func_kwargs)
+    # process the function and check
+    func = _process_parameter_func(_error, func, func_args, func_kwargs, prefs)
     # get the parameter object numbers
     object_nums = Int[]
     for pref in prefs 
@@ -84,7 +182,13 @@ function build_parameter_function(
     # get the parameter numbers 
     param_nums = [_parameter_number(pref) for pref in prefs]
     # make the variable and return
-    return ParameterFunction(func, prefs, object_nums, param_nums)
+    return ParameterFunction(func, prefs, object_nums, param_nums, default_name)
+end 
+
+# Fallback for weird macro inputs
+function build_parameter_function(_error::Function, func, prefs; kwargs...)
+    _error("Invalid syntax causing unexpected parsing of the function and " * 
+           "infinite parameter arguments.")
 end 
 
 # Used to update parameter-parameter function mappings
@@ -101,12 +205,12 @@ end
 
 """
     add_parameter_function(model::InfiniteModel, pfunc::ParameterFunction, 
-                           [name::String = ""])::GeneralVariableRef
+                           [name::String = pfunc.default_name])::GeneralVariableRef
 
 Add an [`ParameterFunction`](@ref) `pfunc` to the `model` using `name` for 
 printing and return a `GeneralVariableRef` such that it can be embedded in 
 expressions. Errors if the infinite parameters `pfunc` points to do not belong to 
-`model`.
+`model`. Note that `pfunc` should be created using [`build_parameter_function`](@ref).
 
 **Example**
 ```julia-repl
@@ -119,12 +223,9 @@ sin(t)
 function add_parameter_function(
     model::InfiniteModel, 
     pfunc::ParameterFunction, 
-    name::String = ""
+    name::String = pfunc.default_name
     )::GeneralVariableRef
     _check_parameters_valid(model, pfunc.parameter_refs)
-    if isempty(name) 
-        name = String(first(methods(pfunc.func)).name)
-    end
     data_object = ParameterFunctionData(pfunc, name)
     findex = _add_data_object(model, data_object)
     fref = ParameterFunctionRef(model, findex)
@@ -168,30 +269,79 @@ function JuMP.set_name(fref::ParameterFunctionRef, name::String)::Nothing
     return
 end
 
+# Helper function choosing the name
+function _select_name(name::Nothing, default_name::String)::String
+    return default_name 
+end
+function _select_name(name::String, default_name::String)::String
+    return name 
+end
+
 """
     parameter_function(func::Function, 
                        pref_inputs::Union{GeneralVariableRef, AbstractArray{GeneralVariableRef}, Tuple}; 
-                       [name::String = ""])::GeneralVariableRef
+                       [name::String = [the name of `func`],
+                       func_args::Union{Tuple, Nothing} = nothing,
+                       func_kwargs::Union{NameTuple, Nothing} = nothing]
+                       )::GeneralVariableRef
 
 Make an infinite parameter function and return a `GeneralVariableRef` that can be 
 embedded in InfiniteOpt expressions. This serves as a convenient wrapper for 
-[`build_parameter_function`](@ref) and [`add_parameter_function`](@ref). Here 
-`func` denotes the function that will take a support of infinite parameters as 
-input (formatted like `pref_inputs`) and will return a scalar value. Errors if 
-`func` will not take such as support as input or if `pref_inputs` follow an invalid 
-input format.
+[`build_parameter_function`](@ref) and [`add_parameter_function`](@ref). For an 
+even more convenient definition method see [`@parameter_function`](@ref).
+
+Here `func` denotes the function that will take a support of infinite parameters as 
+input (formatted like `pref_inputs`) and will return a scalar value. Specifically, 
+`func` should be of the form:
+```
+func(paramvals..., func_args...; func_kwargs...)::Float64
+```
+where the formatting of `paramvals` is analagous to point variables (and will be 
+based on the tuple of infinite parameter references given in `parameter_refs`), 
+extra positional arguments can be given via `fun_args`, and keyword arguments can 
+be  given via `func_kwargs`. Moreover, `func` must be a function that returns a 
+scalar numeric value. 
+
+Errors if `func` will not take a support formatted like `pref_inputs` in 
+combination with the `fargs` and `fkwargs` specified. Also errors if `pref_inputs` 
+follow an invalid input format.
 
 **Example**
 ```julia-repl 
 julia> p_func = parameter_function(sin, t)
 sin(t)
+
+julia> mysin(t_supp, a; b = 1) = a * sin(b * t_supp)
+mysin (generic function with 1 method)
+
+julia> p_func2 = parameter_function(mysin, t, func_args = (2,), func_kwargs = (b = 2,))
+mysin(t)
+
+julia> p_func3 = parameter_function((t_supp) -> 2 * sin(2 * t_supp), t, name = "mysin")
+mysin(t)
+
+julia> p_func4 = parameter_function(t, name = "mysin") do t_supp
+                    if t_supp <= 5
+                        return sin(t_supp)
+                    else 
+                        return 2 * sin(2 * t_supp)
+                    end
+                 end
+
+mysin(t)
 ```
 """
-function parameter_function(func::Function, pref_inputs; 
-                            name::String = "")::GeneralVariableRef
-    f = build_parameter_function(error, func, pref_inputs)
+function parameter_function(
+    func::Function, 
+    pref_inputs; 
+    name::Union{String, Nothing} = nothing,
+    func_args::Union{Tuple, Nothing} = nothing,
+    func_kwargs::Union{NamedTuple, Nothing} = nothing
+    )::GeneralVariableRef
+    f = build_parameter_function(error, func, pref_inputs, func_args = func_args, 
+                                 func_kwargs = func_kwargs)
     model = JuMP.owner_model(first(f.parameter_refs))
-    return add_parameter_function(model, f, name)
+    return add_parameter_function(model, f, _select_name(name, f.default_name))
 end
 
 """
@@ -666,7 +816,7 @@ function _set_variable_coefficient!(expr, var::GeneralVariableRef, coeff::Real)
 end
 
 ################################################################################
-#                         PARAMETER REFERNCE METHODS
+#                         PARAMETER REFERENCE METHODS
 ################################################################################
 ## Return an element of a parameter reference tuple given the model and index
 # IndependentParameterIndex

--- a/src/infinite_variables.jl
+++ b/src/infinite_variables.jl
@@ -96,6 +96,10 @@ function _check_parameter_tuple(_error::Function,
     end
     return
 end
+function _check_parameter_tuple(_error::Function, raw_prefs::VectorTuple{T}) where {T}
+    _error("Expected tuple of infinite parameter references, but got a tuple with ",
+           "elements of type $T")
+end
 
 ## Check and format the variable info considering functional start values
 # Just a number given for the start value
@@ -115,7 +119,7 @@ end
 function _check_valid_function(_error::Function, func::Function, 
                                prefs::VectorTuple)::Nothing 
     input_format = typeof(Tuple(Vector{Float64}(undef, length(prefs)), prefs))
-    if isempty(methods(func, input_format))
+    if !hasmethod(func, input_format)
         _error("Specified function `$func` must be able to accept a `Float64` " * 
                "support realization of the infinite parameter tuple $(prefs).")
     end

--- a/src/macro_utilities.jl
+++ b/src/macro_utilities.jl
@@ -1,6 +1,8 @@
 ################################################################################
 #                                BASIC METHODS
 ################################################################################
+using Base.Meta
+
 # Macro error function
 # inspired from https://github.com/jump-dev/JuMP.jl/blob/709d41b78e56efb4f2c54414266b30932010bd5a/src/macros.jl#L923-L928
 function _macro_error(macroname, args, source, str...)
@@ -13,6 +15,25 @@ end
 _esc_non_constant(x::Number) = x
 _esc_non_constant(x::Expr) = isexpr(x,:quote) ? x : esc(x)
 _esc_non_constant(x) = esc(x)
+
+# Properly convert macro keywords into a keyword argument format 
+# Taken from https://github.com/jump-dev/JuMP.jl/blob/45ce630b51fb1d72f1ff8fed35a887d84ef3edf7/src/variables.jl#L66-L70
+function _keywordify(kw::Expr)
+    return (kw.args[1], _esc_non_constant(kw.args[2]))
+end
+
+# Extract the name from a macro expression 
+# Taken from https://github.com/jump-dev/JuMP.jl/blob/45ce630b51fb1d72f1ff8fed35a887d84ef3edf7/src/Containers/macro.jl#L8-L17
+_get_name(c::Symbol) = c
+_get_name(c::Nothing) = ()
+_get_name(c::AbstractString) = c
+function _get_name(c::Expr)
+    if c.head == :string
+        return c
+    else
+        return c.args[1]
+    end
+end
 
 # Given a base_name and idxvars, returns an expression that constructs the name
 # of the object.
@@ -45,4 +66,73 @@ function _extract_kw_args(args)
         end
     end
     return flat_args, kw_args, requested_container
+end
+
+# Add on keyword arguments to a function call expression and escape the expressions
+# Taken from https://github.com/jump-dev/JuMP.jl/blob/d9cd5fb16c2d0a7e1c06aa9941923492fc9a28b5/src/macros.jl#L11-L36
+function _add_kw_args(call, kw_args)
+    for kw in kw_args
+        @assert isexpr(kw, :(=)) "Unrecognized keyword argument format."
+        push!(call.args, esc(Expr(:kw, kw.args...)))
+    end
+end
+
+# Ensure a model argument is valid
+# Inspired from https://github.com/jump-dev/JuMP.jl/blob/d9cd5fb16c2d0a7e1c06aa9941923492fc9a28b5/src/macros.jl#L38-L44
+_valid_model(m::InfiniteModel, name) = nothing
+function _valid_model(m, name)
+    error("Expected $name to be an `InfiniteModel`, but it has type ", typeof(m))
+end
+
+# Check if a macro julia variable can be registered 
+# Adapted from https://github.com/jump-dev/JuMP.jl/blob/d9cd5fb16c2d0a7e1c06aa9941923492fc9a28b5/src/macros.jl#L66-L86
+function _error_if_cannot_register(model::InfiniteModel, name::Symbol)
+    obj_dict = JuMP.object_dictionary(model)
+    if haskey(obj_dict, name)
+        error(
+            """An object of name $name is already attached to this model. If this
+          is intended, consider using the anonymous construction syntax, e.g.,
+          `x = @finite_variable(model, [1:N], ...)` where the name of the object does
+          not appear inside the macro.
+          Alternatively, use `unregister(model, :$(name))` to first unregister
+          the existing name from the model. Note that this will not delete the
+          object; it will just remove the reference at `model[:$(name)]`.
+      """,
+        )
+    end
+    return
+end
+function _error_if_cannot_register(model::InfiniteModel, name)
+    return error("Invalid name $name.")
+end
+
+# Update the creation code to register and assign the object to the name
+# Taken from https://github.com/jump-dev/JuMP.jl/blob/d9cd5fb16c2d0a7e1c06aa9941923492fc9a28b5/src/macros.jl#L88-L120
+function _macro_assign_and_return(code, variable, name; 
+                                  model_for_registering = nothing)
+    return quote
+        $(
+            if model_for_registering !== nothing
+                :(_error_if_cannot_register(
+                    $model_for_registering,
+                    $(quot(name)),
+                ))
+            end
+        )
+        $variable = $code
+        $(
+            if model_for_registering !== nothing
+                :($model_for_registering[$(quot(name))] = $variable)
+            end
+        )
+        # This assignment should be in the scope calling the macro
+        $(esc(name)) = $variable
+    end
+end
+
+# Wrap the macro generated code for better stacttraces (assumes model is escaped)
+# Taken from https://github.com/jump-dev/JuMP.jl/blob/d9cd5fb16c2d0a7e1c06aa9941923492fc9a28b5/src/macros.jl#L46-L64
+function _finalize_macro(model, code, source::LineNumberNode)
+    return Expr(:block, source, :(_valid_model($model, $(quot(model.args[1])))),
+                code)
 end

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -1,6 +1,4 @@
-using Base.Meta
-using JuMP: _valid_model, _error_if_cannot_register, object_dictionary, variable_type
-using JuMP.Containers
+const Containers = JuMP.Containers
 
 # Parse raw input to define the upper bound for an interval set
 function _parse_one_operator_parameter(
@@ -185,7 +183,7 @@ macro independent_parameter(model, args...)
                            !InfiniteOpt._is_set_keyword(kw) && 
                            kw.args[1] != :error_func, kw_args)
     base_name_kw_args = filter(kw -> kw.args[1] == :base_name, kw_args)
-    infoexpr = InfiniteOpt._ParameterInfoExpr(; JuMP._keywordify.(info_kw_args)...)
+    infoexpr = InfiniteOpt._ParameterInfoExpr(; InfiniteOpt._keywordify.(info_kw_args)...)
 
     # There are five cases to consider:
     # x                                         | type of x | x.head
@@ -193,18 +191,18 @@ macro independent_parameter(model, args...)
     # param                                       | Symbol    | NA
     # param in [lb, ub]                           | Expr      | :call
     # lb <= param <= ub                           | Expr      | :comparison
-    explicit_comparison = InfiniteOpt.isexpr(x, :comparison) || InfiniteOpt.isexpr(x, :call)
+    explicit_comparison = isexpr(x, :comparison) || isexpr(x, :call)
     if explicit_comparison
         param = InfiniteOpt._parse_parameter(_error, infoexpr, x.args...)
     else
         param = x
     end
 
-    anonvar = InfiniteOpt.isexpr(param, :vect) || InfiniteOpt.isexpr(param, :vcat) || anon_singleton
+    anonvar = isexpr(param, :vect) || isexpr(param, :vcat) || anon_singleton
     anonvar && explicit_comparison && _error("Cannot use explicit bounds via " *
                                              ">=, <= with an anonymous parameter")
     parameter = gensym()
-    name = JuMPC._get_name(param)
+    name = _get_name(param)
     if isempty(base_name_kw_args)
         base_name = anonvar ? "" : string(name)
     else
@@ -221,7 +219,7 @@ macro independent_parameter(model, args...)
     if isa(param, Symbol)
         # Easy case - a single variable
         buildcall = :( build_parameter($_error, $set) )
-        JuMP._add_kw_args(buildcall, extra_kw_args)
+        _add_kw_args(buildcall, extra_kw_args)
         parametercall = :( add_parameter($esc_model, $buildcall, $base_name) )
         creationcode = :($parameter = $parametercall)
     else
@@ -230,7 +228,7 @@ macro independent_parameter(model, args...)
         # SparseAxisArray to contain them)
         idxvars, indices = JuMPC._build_ref_sets(_error, param)
         buildcall = :( build_parameter($_error, $set) )
-        JuMP._add_kw_args(buildcall, extra_kw_args)
+        _add_kw_args(buildcall, extra_kw_args)
         parametercall = :( add_parameter($esc_model, $buildcall,
                                          $(_name_call(base_name, idxvars))) )
         creationcode = JuMPC.container_code(idxvars, indices, parametercall,
@@ -244,10 +242,10 @@ macro independent_parameter(model, args...)
     else
         # We register the variable reference to its name and
         # we assign it to a variable in the local scope of this name
-        macro_code = JuMP._macro_assign_and_return(creationcode, parameter, name,
-                                                   model_for_registering = esc_model)
+        macro_code = _macro_assign_and_return(creationcode, parameter, name,
+                                              model_for_registering = esc_model)
     end
-    return JuMP._finalize_macro(esc_model, macro_code, __source__)
+    return _finalize_macro(esc_model, macro_code, __source__)
 end
 
 """
@@ -324,7 +322,7 @@ macro finite_parameter(model, args...)
     anonvar = isexpr(param, :vect) || isexpr(param, :vcat) || anon_singleton
 
     parameter = gensym()
-    name = JuMPC._get_name(param)
+    name = _get_name(param)
     if isempty(base_name_kw_args)
         base_name = anonvar ? "" : string(name)
     else
@@ -339,13 +337,13 @@ macro finite_parameter(model, args...)
 
     if isa(param, Symbol)
         buildcall = :( build_parameter($_error, $value) )
-        JuMP._add_kw_args(buildcall, extra_kw_args)
+        _add_kw_args(buildcall, extra_kw_args)
         parametercall = :( add_parameter($esc_model, $buildcall, $base_name) )
         creationcode = :($parameter = $parametercall)
     else
         idxvars, indices = JuMPC._build_ref_sets(_error, param)
         buildcall = :( build_parameter($_error, $value) )
-        JuMP._add_kw_args(buildcall, extra_kw_args)
+        _add_kw_args(buildcall, extra_kw_args)
         parametercall = :( add_parameter($esc_model, $buildcall,
                                          $(_name_call(base_name, idxvars))) )
         creationcode = JuMPC.container_code(idxvars, indices, parametercall,
@@ -354,10 +352,10 @@ macro finite_parameter(model, args...)
     if anonvar
         macro_code = creationcode
     else
-        macro_code = JuMP._macro_assign_and_return(creationcode, parameter, name,
-                                                   model_for_registering = esc_model)
+        macro_code = _macro_assign_and_return(creationcode, parameter, name,
+                                              model_for_registering = esc_model)
     end
-    return JuMP._finalize_macro(esc_model, macro_code, __source__)
+    return _finalize_macro(esc_model, macro_code, __source__)
 end
 
 """
@@ -492,7 +490,7 @@ macro dependent_parameters(model, args...)
                                         "with an anonymous parameter")
     # process the parameter name
     parameter = gensym()
-    name = JuMPC._get_name(param)
+    name = _get_name(param)
     if isempty(base_name_kw_args)
         base_name = anonparam ? "" : string(name)
     else
@@ -528,17 +526,17 @@ macro dependent_parameters(model, args...)
     param_container_call = JuMPC.container_code(idxvars, indices, parambuildcall,
                                                 requestedcontainer)
     buildcall = :( InfiniteOpt._build_parameters($_error, $param_container_call) )
-    JuMP._add_kw_args(buildcall, extra_kw_args)
+    _add_kw_args(buildcall, extra_kw_args)
     creationcode = :( add_parameters($esc_model, $(buildcall)...) )
 
     # make the final return code based on if it is anonymous or not
     if anonparam
         macro_code = creationcode
     else
-        macro_code = JuMP._macro_assign_and_return(creationcode, parameter, name,
-                                                   model_for_registering = esc_model)
+        macro_code = _macro_assign_and_return(creationcode, parameter, name,
+                                              model_for_registering = esc_model)
     end
-    return JuMP._finalize_macro(esc_model, macro_code, __source__)
+    return _finalize_macro(esc_model, macro_code, __source__)
 end
 
 """
@@ -889,7 +887,7 @@ macro infinite_variable(model, args...)
         end
 
         # check for double specification of parameters
-        if length(param_kw_args) != 0 && params != nothing
+        if length(param_kw_args) != 0 && params !== nothing
             _error("Cannot specify double specify the infinite parameter " *
                    "references.")
         end
@@ -928,6 +926,14 @@ macro infinite_variable(model, args...)
         end
     end
     return esc(code)
+end
+
+# Helper method for checking that function call is not from an operator
+function _ensure_not_operator(_error::Function, func)
+    if func in [:in, :<=, :>=, :(==), :≥, :≤, ∈]
+        _error("Invalid input syntax.")
+    end
+    return
 end
 
 """
@@ -1068,9 +1074,8 @@ macro point_variable(model, args...)
             if length(param_kw_args) != 0
                 _error("Cannot double specify the infinite variable reference " *
                        "and/or its parameter values.")
-            elseif x.args[1] in [:in, :<=, :>=, :(==), :≥, :≤, ∈]
-                _error("Invalid input syntax.")
             end
+            _ensure_not_operator(_error, x.args[1])
             rest_args = [args[i] for i = 2:length(args)]
             inf_var = x.args[1]
             param_vals = Expr(:tuple, x.args[2:end]...)
@@ -1235,6 +1240,253 @@ macro hold_variable(model, args...)
         @finite_variable($model, ($(args...)))
     end
     return esc(code)
+end
+
+# Helper method to process parameter function expressions 
+function _process_func_expr(_error::Function, raw_expr, pref_expr)
+    if isexpr(raw_expr, :call)
+        # we have symbolic arguments given 
+        _ensure_not_operator(_error, raw_expr.args[1])
+        func_expr = _esc_non_constant(raw_expr.args[1])
+        # restructure to expected in case keywords were given using ;
+        if length(raw_expr.args) > 1 && isexpr(raw_expr.args[2], :parameters)
+            append!(raw_expr.args, raw_expr.args[2].args)
+            deleteat!(raw_expr.args, 2)
+        end
+        # check that the prefs are given first and match the pref_expr
+        num_pref_args = length(pref_expr.args)
+        if length(raw_expr.args) <= num_pref_args || pref_expr.args != raw_expr.args[2:num_pref_args+1]
+            _error("Inconsistent infinite parameter reference dependencies.")
+        end 
+        # extract the extra arguments given symbolically
+        extra_func_args = raw_expr.args[num_pref_args+2:end]
+        raw_fargs = filter(e -> !isexpr(e, :kw), extra_func_args)
+        if isempty(raw_fargs) 
+            fargs = nothing
+        else
+            fargs = esc(Expr(:tuple, raw_fargs...))
+        end
+        # extract the keyword arguments given symbolically
+        raw_fkwargs = filter(e -> isexpr(e, :kw), extra_func_args)
+        if isempty(raw_fkwargs)
+            fkwargs = nothing
+        else
+            fkwargs = esc(Expr(:tuple, map(e -> Expr(:(=), e.args...), raw_fkwargs)...))
+        end
+    else 
+        # easy case where only the function name was given
+        func_expr = _esc_non_constant(raw_expr)
+        fargs = nothing
+        fkwargs = nothing
+    end
+    return func_expr, fargs, fkwargs
+end
+
+"""
+    @parameter_function(model::InfiniteModel, kw_args...)::GeneralVariableRef
+
+Add an *anonymous* parameter function to the model `model` described by the
+keyword arguments `kw_args` and returns the object reference. Note that the
+`func` and `parameter_refs` keywords are required in this
+case.
+
+```julia
+@parameter_function(model::InfiniteModel, varexpr, funcexpr, kw_args...)::GeneralVariableRef
+
+@parameter_function(model::InfiniteModel, varexpr == funcexpr, kw_args...)::GeneralVariableRef
+```
+
+Add a parameter function to `model` described by the expression `varexpr`, the
+function expression `funcexpr`, and the keyword arguments `kw_args`. The expression 
+`varexpr` is used to define the parameter function references and determine the 
+infinite parameters that are intended for this function. Here the accepted forms 
+are:
+- `varname(params...)` creating a scalar parameter function with alias name `varname` 
+  that depends on the parameter references `params...`
+- `varname[...](params...)` or `[...](params...)` creating a container of parameter 
+  functions with parameter references given in `paramexpr`.
+The expression `params` can match that of the `parameter_refs` keyword argument 
+(see the keyword argument description for info on accepted formats). 
+
+The expression `funcexpr` determines the concrete Julia function that defines the 
+behavior of parameter function and allows us to specify the `func`, `func_args`, 
+and/or `func_kwargs` keyword arguments. The accepted forms are:
+- `funcname`: Give the name of the concrete Julia function or give an anonymous function
+- `funcname(params..., func_args..., func_kwargs...)`: Provide the concrete Julia 
+  function name and provide the addtional positional/keyword arguments as needed.
+  Note the at the format of `params` must match that provided in `varexpr`. 
+
+The recognized keyword arguments in `kw_args` are the following:
+- `parameter_refs`: This is mandatory if not specified in `varexpr`. Can be a
+  single parameter reference, a single parameter array with parameters defined
+  in the same call of [`@infinite_parameter`](@ref),
+  or a tuple where each element is either of the first two options listed.
+- `func`: A concrete Julia function of the form 
+  `func(paramvals..., func_args...; func_kwargs...)::Float64` where the format of 
+  `param_vals` matches that of `parameter_refs` but accepts numeric supports. We could 
+  also instead give an anonymous function.
+- `func_args`: A `Tuple` of additional positional arguments for `func`
+- `func_kwargs`: A `NameTuple` of keyword arguments for `func`
+- `base_name`: Sets the name prefix used to generate object names. It
+  corresponds to the object name for scalar parameter function, otherwise, the
+  object names are set to `base_name[...]` for each index `...` of the axes
+  `axes`.
+- `container`: Specify the container type.
+
+**Examples**
+```julia-repl 
+julia> @parameter_function(model, func = sin, parameter_refs = t, base_name = "sin")
+sin(t)
+
+julia> @parameter_function(model, [i = 1:2], func = [sin, cos][i], parameter_refs = t)
+2-element Array{GeneralVariableRef,1}:
+ noname(t)
+ noname(t)
+
+julia> f(t_val, x_vals) = t_val + sum(x_vals)
+f (generic function with 1 method)
+
+julia> @parameter_function(model, pf(t, x) == f)
+pf(t, x)
+
+julia> g(t_val, a; b = 0) = t_val + a + b
+g (generic function with 1 method)
+
+julia> @parameter_function(model, pf2[i = 1:2](t) == g(t, i, b = 2 * i ))
+2-element Array{GeneralVariableRef,1}:
+ pf2[1](t)
+ pf2[2](t)
+
+julia> @parameter_function(model, pf2_alt[i = 1:2](t) == t -> g(t, i, b = 2 * i ))
+2-element Array{GeneralVariableRef,1}:
+ pf2_alt[1](t)
+ pf2_alt[2](t)
+```
+"""
+macro parameter_function(model, args...)
+    # prepare the model 
+    esc_model = esc(model)
+
+    # define error message function
+    _error(str...) = _macro_error(:parameter_function, (model, args...),
+                                  __source__, str...)
+
+    # parse the arguments
+    extra, kwargs, requestedcontainer = _extract_kw_args(args)
+    func_kwarg = filter(kw -> kw.args[1] == :func, kwargs)
+    prefs_kwarg = filter(kw -> kw.args[1] == :parameter_refs, kwargs)
+    fargs_kwarg = filter(kw -> kw.args[1] == :func_args, kwargs)
+    fkwargs_kwarg = filter(kw -> kw.args[1] == :func_kwargs, kwargs)
+    base_name_kwarg = filter(kw -> kw.args[1] == :base_name, kwargs)
+    filter!(kw -> kw.args[1] != :func && kw.args[1] != :parameter_refs &&
+            kw.args[1] != :base_name && kw.args[1] == :func_args &&
+            kw.args[1] == :func_kwargs, kwargs)
+
+    # if an equality syntax is given convert it into 2 separate arguments
+    if length(extra) == 1 && isexpr(extra[1], :call) && extra[1].args[1] == :(==)
+        extra = [extra[1].args[2], extra[1].args[3]]
+    end
+
+    # process and extract the symbolic inputs
+    fargs = nothing
+    fkwargs = nothing
+    anon_kwargs = !isempty(func_kwarg) && !isempty(prefs_kwarg)
+    if isempty(extra) && anon_kwargs
+        # single anonymous definition
+        var_expr = gensym()
+        func_expr = _esc_non_constant(func_kwarg[1].args[2])
+        pref_expr = _esc_non_constant(prefs_kwarg[1].args[2])
+        anon = true
+    elseif length(extra) == 1 && (isexpr(extra[1], :vect) || isexpr(extra[1], :vcat)) && anon_kwargs
+        # container definition of anonymous parameter functions
+        var_expr = extra[1]
+        func_expr = _esc_non_constant(func_kwarg[1].args[2])
+        pref_expr = _esc_non_constant(prefs_kwarg[1].args[2])
+        anon = true
+    elseif isempty(extra) || (length(extra) == 1 && (isexpr(extra[1], :vect) || isexpr(extra[1], :vcat)))
+        # we have one of the above situations, but not enough information
+        _error("Anonymous calls must specify both the `func` and " *
+               "`parameter_refs` keyword arguments.")
+    elseif !isempty(func_kwarg) || !isempty(prefs_kwarg)
+        # anonymous keyword args cannot be mixed with symbolic syntax
+        _error("Keyword arguments `func` and `parameter_refs` are only for " * 
+               "anonymous parameter function definitions.")
+    elseif length(extra) == 2 && isexpr(extra[1], :call)
+        # 2 argument symbolic definition which may or may not be anonymous
+        # anonymous if the first argument is of form [idx_expr](pref_expr)
+        # otherwise the first argument should be name[idx_expr](pref_expr) or name(pref_expr)
+        _ensure_not_operator(_error, extra[1].args[1])
+        var_expr = extra[1].args[1]
+        pref_expr = Expr(:tuple, extra[1].args[2:end]...)
+        func_expr, fargs, fkwargs = _process_func_expr(_error, extra[2], pref_expr)
+        pref_expr = esc(pref_expr)
+        anon = isexpr(var_expr, :vect) || isexpr(var_expr, :vcat)
+    elseif length(extra) == 2 
+        # some other 2 argument syntax
+        _error("Invalid explicit syntax, should be of form ",
+               "`@parameter_function(model, nameexpr(params...), funcexpr, kwargs...)")
+    elseif length(extra) > 2
+        # cannot have more than 2 positional arguments
+        _error("Too many positional arguments.")
+    else
+        # something else was given incorrectly with one positional argument
+        _error("Invalid syntax.")
+    end
+
+    # parse the base name appropriately
+    name = _get_name(var_expr)
+    if isempty(base_name_kwarg)
+        base_name = anon ? "" : string(name) # TODO perhaps change default behavior
+    else
+        base_name = esc(base_name_kwarg[1].args[2])
+    end
+    if !isa(name, Symbol) && !anon
+        _error("Expression $name should not be used as a parameter function name. Use " *
+               "the \"anonymous\" syntax $name = @parameter_function(model, " *
+               "...) instead.")
+    end
+
+    # update and check fargs
+    if !isempty(fargs_kwarg) && fargs === nothing 
+        fargs = _esc_non_constant(fargs_kwarg[1].args[2])
+    elseif !isempty(fargs_kwarg)
+        _error("Cannot double specify the `func_args` keyword argument.")
+    end
+
+    # update and check fkwargs
+    if !isempty(fkwargs_kwarg) && fkwargs === nothing 
+        fkwargs = _esc_non_constant(fkwargs_kwarg[1].args[2])
+    elseif !isempty(fkwargs_kwarg)
+        _error("Cannot double specify the `func_kwargs` keyword argument.")
+    end
+
+    # generate the needed code 
+    pfunc = gensym()
+    buildcall = :( build_parameter_function($_error, $func_expr, $pref_expr, 
+                                                func_args = $fargs, 
+                                                func_kwargs = $fkwargs) )
+    _add_kw_args(buildcall, kwargs)
+    if isa(var_expr, Symbol)
+        # create a single parameter function 
+        pfunctioncall = :( add_parameter_function($esc_model, $buildcall, $base_name) )
+        creationcode = :( $pfunc = $pfunctioncall )
+    else
+        # create code for a container 
+        idxvars, indices = JuMPC._build_ref_sets(_error, var_expr)
+        pfunctioncall = :( add_parameter_function($esc_model, $buildcall,
+                                         $(_name_call(base_name, idxvars))) )
+        creationcode = JuMPC.container_code(idxvars, indices, pfunctioncall,
+                                            requestedcontainer)
+    end
+    if anon
+        # anonymous creation
+        macro_code = creationcode
+    else
+        # want to register the object/container reference
+        macro_code = _macro_assign_and_return(creationcode, pfunc, name,
+                                              model_for_registering = esc_model)
+    end
+    return _finalize_macro(esc_model, macro_code, __source__)
 end
 
 ## Parse derivative numerators and denominators 

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -97,3 +97,12 @@ function _make_float_info(
     )::JuMP.VariableInfo{Float64, Float64, Float64, Float64}
     return info
 end
+
+# Make a string of NamedTuple arguments 
+function _kwargs2string(nt::NamedTuple)::String
+    if length(nt) == 1
+        return string(nt)[2:end-2]
+    else
+        return string(nt)[2:end-1]
+    end
+end

--- a/test/datatypes.jl
+++ b/test/datatypes.jl
@@ -372,9 +372,9 @@ end
     pref = GeneralVariableRef(m, 1, IndependentParameterIndex, -1)
     vt = IC.VectorTuple(pref)
     # test ParameterFunction
-    @test ParameterFunction(sin, vt, [1], [1]) isa ParameterFunction
+    @test ParameterFunction(sin, vt, [1], [1], "") isa ParameterFunction
     # test ParameterFunctionData
-    @test ParameterFunctionData(ParameterFunction(sin, vt, [1], [1])) isa ParameterFunctionData
+    @test ParameterFunctionData(ParameterFunction(sin, vt, [1], [1], "")) isa ParameterFunctionData
 end
 
 # Test variable datatypes

--- a/test/expressions.jl
+++ b/test/expressions.jl
@@ -303,7 +303,7 @@ end
         idx += 1
         ref = GeneralVariableRef(m, idx, ParameterFunctionIndex)
         @test @parameter_function(m, func = f5, parameter_refs = (t, x), 
-                                  fun_args = (1,), func_kwargs = (d = 1,)) == ref
+                                  func_args = (1,), func_kwargs = (d = 1,)) == ref
         @test name(ref) == ""
         @test raw_function(ref) != f5
         @test raw_function(ref)(1, [1, 1]) == 42

--- a/test/infinite_variables.jl
+++ b/test/infinite_variables.jl
@@ -222,6 +222,8 @@ end
         @test_throws ErrorException InfiniteOpt._check_parameter_tuple(error, tuple)
         tuple = IC.VectorTuple(fin)
         @test_throws ErrorException InfiniteOpt._check_parameter_tuple(error, tuple)
+        tuple = IC.VectorTuple(2)
+        @test_throws ErrorException InfiniteOpt._check_parameter_tuple(error, tuple)
     end
     # _check_and_format_infinite_info (Real)
     @testset "_check_and_format_infinite_info (Real)" begin

--- a/test/macro_utilities.jl
+++ b/test/macro_utilities.jl
@@ -12,6 +12,18 @@
         @test InfiniteOpt._esc_non_constant(:(x[i])) == esc(:(x[i]))
         @test InfiniteOpt._esc_non_constant(:x) == esc(:x)
     end
+    # test _keywordify
+    @testset "_keywordify" begin 
+        @test InfiniteOpt._keywordify(Expr(:kw, :d, 1)) == (:d, 1)
+    end
+    # test _get_name
+    @testset "_get_name" begin 
+        @test InfiniteOpt._get_name(:a) == :a
+        @test InfiniteOpt._get_name(nothing) == ()
+        @test InfiniteOpt._get_name("bob") == "bob"
+        @test InfiniteOpt._get_name(:("a$(x)")) == :("a$(x)")
+        @test InfiniteOpt._get_name(:(x[1:2])) == :x 
+    end
     # test _name_call 
     @testset "_name_call" begin 
         @test InfiniteOpt._name_call("bob", []) == "bob"
@@ -25,5 +37,43 @@
         @test InfiniteOpt._extract_kw_args(args)[1] == [:x]
         @test InfiniteOpt._extract_kw_args(args)[2] == [:(d=42)]
         @test InfiniteOpt._extract_kw_args(args)[3] == :(Cat)
+    end
+    # test _add_kw_args
+    @testset "_add_kw_args" begin
+        esc_kw = esc(Expr(:kw, :d, 2))
+        call = :(f(a))
+        @test InfiniteOpt._add_kw_args(call, [:(d = 2)]) isa Nothing
+        @test call == :(f(a, $esc_kw))
+        @test_throws AssertionError InfiniteOpt._add_kw_args(:(f(a)), [:((s, 2))])
+    end
+    # test _valid_model
+    @testset "_valid_model" begin
+        m = InfiniteModel()
+        m2 = 2
+        @test InfiniteOpt._valid_model(m, :m) isa Nothing
+        @test_throws ErrorException InfiniteOpt._valid_model(m2, :m2)
+    end
+    # test _error_if_cannot_register
+    @testset "_error_if_cannot_register" begin
+        m = InfiniteModel()
+        @test InfiniteOpt._error_if_cannot_register(m, :x) isa Nothing
+        object_dictionary(m)[:x] = 2
+        @test_throws ErrorException InfiniteOpt._error_if_cannot_register(m, :x)
+        @test_throws ErrorException InfiniteOpt._error_if_cannot_register(m, :((x, 2)))
+    end
+    # test _macro_assign_and_return
+    @testset "_macro_assign_and_return" begin
+        m = InfiniteModel()
+        esc_m = esc(:m)
+        code = :(GeneralVariableRef($esc_m, 1, FiniteVariableIndex))
+        @test InfiniteOpt._macro_assign_and_return(code, :var, :a, model_for_registering = esc_m) isa Expr
+    end
+    # test _finalize_macro
+    @testset "_finalize_macro" begin
+        m = InfiniteModel()
+        esc_m = esc(:m)
+        code = :(GeneralVariableRef($esc_m, 1, FiniteVariableIndex))
+        source = LineNumberNode(42, :bob)
+        @test InfiniteOpt._finalize_macro(esc_m, code, source) isa Expr
     end
 end

--- a/test/point_variables.jl
+++ b/test/point_variables.jl
@@ -506,6 +506,11 @@ end
     @infinite_parameter(m, x[1:2] in [-1, 1])
     @infinite_variable(m, 0 <= z(t, x) <= 1, Int, start = (a, x) -> a + sum(x))
     @infinite_variable(m, z2[1:2](t) == 3)
+    # test _ensure_not_operator
+    @testset "_ensure_not_operator" begin 
+        @test InfiniteOpt._ensure_not_operator(error, :f) isa Nothing 
+        @test_throws ErrorException InfiniteOpt._ensure_not_operator(error, :in)
+    end
     # test single variable definition
     @testset "Single" begin
         # test simple anon case

--- a/test/utility_tests.jl
+++ b/test/utility_tests.jl
@@ -107,3 +107,11 @@ end
     @test InfiniteOpt._make_float_info(info1) isa VariableInfo{Float64, Float64, Float64, Float64}
     @test InfiniteOpt._make_float_info(info2) == info2
 end
+
+# Test _kwargs2string
+@testset "_kwargs2string" begin
+    nt1 = (d = 1,)
+    nt2 = (d = 1, e = 2)
+    @test InfiniteOpt._kwargs2string(nt1) == "d = 1"
+    @test InfiniteOpt._kwargs2string(nt2) == "d = 1, e = 2"
+end


### PR DESCRIPTION
Closes #115 and #93.

This also partially addresses #60 in removing all the internal JuMP functions except for `JuMP.Containers._build_ref_sets`. 
