### PR TITLE
Revamped Exporting Configuration

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,14 +9,16 @@ MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 FastGaussQuadrature = "442a2c76-b920-505d-bb47-c5924d526838"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
+Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 
 [compat]
 julia = "1"
-JuMP = "~0.21.6"
-FastGaussQuadrature = "^0.3.2, ~0.4"
-Distributions = "~0.19, ~0.20, ~0.21, ~0.22, ~0.23, ~0.24"
-MathOptInterface = "~0.9.16"
-DataStructures = "^0.14.2, ~0.15, ~0.16, ~0.17, ~0.18"
+JuMP = "0.21.6"
+FastGaussQuadrature = "^0.3.2, 0.4"
+Distributions = "0.19, 0.20, 0.21, 0.22, 0.23, 0.24"
+MathOptInterface = "0.9.19"
+DataStructures = "^0.14.2, 0.15, 0.16, 0.17, 0.18"
+Reexport = "0.2, 1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -77,7 +77,7 @@ ybar3 = 0           # no upper bound on the other crops
 ```
 Great now we can formulate and solve the problem using `InfiniteOpt`:
 ```jldoctest 2-stage; output = false
-using InfiniteOpt, JuMP, Ipopt, Random
+using InfiniteOpt, Ipopt, Random
 
 # Seed for repeatability
 Random.seed!(0)
@@ -199,7 +199,7 @@ horizon.
 
 Let's implement this in `InfiniteOpt`:
 ```jldoctest hovercraft; output = false
-using InfiniteOpt, JuMP, Ipopt
+using InfiniteOpt, Ipopt
 
 # Waypoints
 xw = [1 4 6 1; 1 3 0 1] # positions

--- a/docs/src/extensions.md
+++ b/docs/src/extensions.md
@@ -24,7 +24,7 @@ As an example, let's create a univariate disjoint interval set as an infinite se
 This corresponds to the set ``[lb_1, ub_1] \cup [lb_2, ub_2]`` where
 ``ub_1 \leq lb_2``. First, we need to create the `DataType` with inheritance from [`InfiniteScalarSet`](@ref):
 ```jldoctest set_ext; output = false
-using InfiniteOpt, JuMP
+using InfiniteOpt
 
 struct DisjointSet <: InfiniteOpt.InfiniteScalarSet
     lb1::Float64
@@ -168,7 +168,7 @@ y(t_{n+1}) = y(t_n) + (t_{n+1} - t_{n})\frac{d y(t_n)}{dt}, \ \forall n = 0, 1, 
 
 Let's get started with step 1 and define our new method struct:
 ```jldoctest deriv_ext; output = false
-using InfiniteOpt, JuMP
+using InfiniteOpt
 
 struct ExplicitEuler <: NonGenerativeDerivativeMethod end
 
@@ -405,9 +405,7 @@ implement this example to illustrate the mechanics of extension.
 
 First, let's define our new `struct` inheriting from `AbstractMeasureData`:
 ```jldoctest measure_data; output = false
-using InfiniteOpt, JuMP, Distributions
-
-const JuMPC = JuMP.Containers
+using InfiniteOpt, Distributions
 
 struct DiscreteVarianceData <: AbstractMeasureData
     parameter_refs::Union{GeneralVariableRef, Vector{GeneralVariableRef}}
@@ -670,7 +668,7 @@ First, let's define the `mutable struct` that will be used to store our variable
 and constraint mappings. This case it is quite simple since our deterministic
 model will have a 1-to-1 mapping:
 ```jldoctest opt_model; output = false
-using InfiniteOpt, JuMP, Distributions
+using InfiniteOpt, Distributions
 
 mutable struct DeterministicData
     # variable and constraint mapping

--- a/docs/src/guide/constraint.md
+++ b/docs/src/guide/constraint.md
@@ -21,7 +21,7 @@ typical finite and infinite constraints and `@BDconstraint` is used to specify
 bounded constraints (i.e., infinite constraints with a constrained sub-domain
 of its full infinite domain). First, let's setup an infinite model with
 variables that we can add constraints to:
-```jldoctest constrs; setup = :(using InfiniteOpt, JuMP, Distributions)
+```jldoctest constrs; setup = :(using InfiniteOpt, Distributions)
 julia> model = InfiniteModel();
 
 julia> @infinite_parameter(model, t in [0, 10]);
@@ -157,7 +157,7 @@ The constraint objects are specified via
 a `JuMP.AbstractJuMPScalar`, a `MOI.AbstractScalarSet`, and any keyword
 arguments such as `ParameterBound`. For example, let's build a scalar constraint
 for ``3T(t, x) - g^2(t) \leq 0``:
-```jldoctest constrs; setup = :(using MathOptInterface; const MOI = MathOptInterface)
+```jldoctest constrs
 julia> constr = build_constraint(error, 3T - g^2, MOI.LessThan(0.0))
 ScalarConstraint{GenericQuadExpr{Float64,GeneralVariableRef},MathOptInterface.LessThan{Float64}}(-g(t)² + 3 T(t, x), MathOptInterface.LessThan{Float64}(0.0))
 ```

--- a/docs/src/guide/constraint.md
+++ b/docs/src/guide/constraint.md
@@ -368,11 +368,11 @@ julia> num_constraints(model) # total number of constraints
 julia> num_constraints(model, GenericQuadExpr{Float64,GeneralVariableRef})
 5
 
-julia> num_constraints(model, MathOptInterface.LessThan{Float64})
+julia> num_constraints(model, MOI.LessThan{Float64})
 6
 
 julia> num_constraints(model, GenericQuadExpr{Float64,GeneralVariableRef},
-                       MathOptInterface.LessThan{Float64})
+                       MOI.LessThan{Float64})
 4                   
 ```
 

--- a/docs/src/guide/derivative.md
+++ b/docs/src/guide/derivative.md
@@ -13,7 +13,7 @@ partial derivatives. Derivatives can be used in defining measures and constraint
 Derivative operators can defined a few different ways in `InfiniteOpt`. To motivate 
 these, let's first define an `InfiniteModel` along with some parameters and variables:
 ```jldoctest deriv_basic
-julia> using InfiniteOpt, JuMP, Distributions;
+julia> using InfiniteOpt, Distributions;
 
 julia> model = InfiniteModel();
 

--- a/docs/src/guide/expression.md
+++ b/docs/src/guide/expression.md
@@ -22,7 +22,7 @@ constrained to a particular known function. This is accomplished via
 [`@parameter_function`](@ref) or [`parameter_function`](@ref) and is exemplified 
 by defining a parameter function `f(t)` that uses `sin(t)`:
 ```jldoctest param_func
-julia> using InfiniteOpt, JuMP;
+julia> using InfiniteOpt;
 
 julia> model = InfiniteModel();
 
@@ -140,7 +140,7 @@ In `InfiniteOpt`, affine expressions can be defined directly
 using `Julia`'s arithmetic operators (i.e., `+`, `-`, `*`, etc.) or using
 [`@expression`](@ref).  For example, let's define the expression
 ``2y(t) + z - 3t`` noting that the following methods are equivalent:
-```jldoctest affine; setup = :(using InfiniteOpt, JuMP; model = InfiniteModel())
+```jldoctest affine; setup = :(using InfiniteOpt; model = InfiniteModel())
 julia> @infinite_parameter(model, t in [0, 10])
 t
 

--- a/docs/src/guide/finite_parameter.md
+++ b/docs/src/guide/finite_parameter.md
@@ -19,7 +19,7 @@ variables.
 Once an `InfiniteModel` `model` has been defined we can add a finite parameter
 via [`@finite_parameter`](@ref). For example, let's define a maximum cost
 parameter called `max_cost` with an initial value of `42`:
-```jldoctest fpar; setup = :(using InfiniteOpt, JuMP; model = InfiniteModel())
+```jldoctest fpar; setup = :(using InfiniteOpt; model = InfiniteModel())
 julia> @finite_parameter(model, max_cost, 42)
 max_cost
 ```

--- a/docs/src/guide/install.md
+++ b/docs/src/guide/install.md
@@ -46,7 +46,7 @@ For example, we can install Ipopt which is an open-source nonlinear solver:
 ```
 Now Ipopt can be used as the optimizer (solver) for an infinite model by running:
 ```julia-repl
-julia> using InfiniteOpt, JuMP, Ipopt
+julia> using InfiniteOpt, Ipopt
 
 julia> model = InfiniteModel(Ipopt.Optimizer)
 ```

--- a/docs/src/guide/measure.md
+++ b/docs/src/guide/measure.md
@@ -19,7 +19,7 @@ we support the use of alternative measure operator paradigms.
 First, we consider a dynamic optimization problem with the time parameter `t`
 from 0 to 10. We also consider a state variable `y(t)` and a control variable
 `u(t)` that are parameterized by `t`:
-```jldoctest meas_basic; setup = :(using InfiniteOpt, JuMP, Random; Random.seed!(0); model = InfiniteModel())
+```jldoctest meas_basic; setup = :(using InfiniteOpt, Random; Random.seed!(0); model = InfiniteModel())
 julia> @infinite_parameter(model, t in [0, 10], supports = [0, 5, 10])
 t
 
@@ -67,7 +67,7 @@ and [`support_sum`](@ref) for summing an expression over the support points of
 selected infinite parameters. The syntax for these is analogous to that of `integral` 
 except that there are no lower/upper bounds. For example, we can define the following 
 expectation of a random expression:
-```jldoctest; setup = :(using InfiniteOpt, JuMP, Distributions)
+```jldoctest; setup = :(using InfiniteOpt, Distributions)
 julia> m = InfiniteModel();
 
 julia> @infinite_parameter(m, ξ in Normal(), num_supports = 100);
@@ -322,7 +322,7 @@ There is a difference in how supports are considered using `UniTrapezoid()`/`FEG
 the other schemes. Namely, the other schemes will NOT incorporate other supports 
 specified elsewhere in the model. Consider the following example with 3 equidistant 
 supports and an integral objective function that uses `UniTrapezoid()` (the default):
-```jldoctest support_manage; setup = :(using InfiniteOpt, JuMP), output = false
+```jldoctest support_manage; setup = :(using InfiniteOpt), output = false
 # Create a model, with one variable and an infinite parameter with a given number of supports
 m = InfiniteModel()
 @infinite_parameter(m, t in [0, 2], num_supports = 3)

--- a/docs/src/guide/model.md
+++ b/docs/src/guide/model.md
@@ -14,7 +14,7 @@ model backend.
 ## Basic Usage
 Infinite models can be initialized with no arguments by default:
 ```jldoctest
-julia> using InfiniteOpt, JuMP
+julia> using InfiniteOpt
 
 julia> model = InfiniteModel()
 An InfiniteOpt Model
@@ -33,7 +33,7 @@ Solver name: No optimizer attached.
 The optimizer that will be used to solve the model can also be specified at
 model definition:
 ```jldoctest
-julia> using InfiniteOpt, JuMP, Ipopt
+julia> using InfiniteOpt, Ipopt
 
 julia> model = InfiniteModel(Ipopt.Optimizer)
 An InfiniteOpt Model
@@ -56,7 +56,7 @@ We can also specify optimizer attributes via
 [`optimizer_with_attributes`](@ref JuMP.optimizer_with_attributes(::Any, ::Pair))
 which allows us to append as many attributes as we like, for example:
 ```jldoctest
-julia> using InfiniteOpt, JuMP, Ipopt
+julia> using InfiniteOpt, Ipopt
 
 julia> model = InfiniteModel(optimizer_with_attributes(Ipopt.Optimizer,
                                                        "output_level" => 0))
@@ -95,9 +95,7 @@ model by including it in the `InfiniteModel` constructor. For example, we can
 specify the `caching_mode` keyword argument in the `InfiniteModel` call to use
 in the definition of the optimizer model:
 ```jldoctest
-julia> using InfiniteOpt, JuMP, Ipopt, MathOptInterface
-
-julia> const MOIU = MathOptInterface.Utilities;
+julia> using InfiniteOpt, Ipopt
 
 julia> model = InfiniteModel(Ipopt.Optimizer,
                              caching_mode = MOIU.MANUAL)
@@ -148,7 +146,7 @@ Like `JuMP.Model`s, `InfiniteModel`s register the name symbols of macro defined
 objects. This enables us to access such objects by indexing the `InfiniteModel` 
 with the appropriate symbol. This is particularly useful for function defined 
 models. For example:
-```jldoctest; setup = :(using InfiniteOpt, JuMP)
+```jldoctest; setup = :(using InfiniteOpt)
 julia> function make_model(num_supports)
         model = InfiniteModel()
         @infinite_parameter(model, t ∈ [0, 10], num_supports = num_supports)

--- a/docs/src/guide/objective.md
+++ b/docs/src/guide/objective.md
@@ -16,7 +16,7 @@ measure to be included (e.g., evaluate the expectation of a random variable).
 Principally, the objective function is specified via [`@objective`](@ref) as is
 done in `JuMP`. For example, let's define the stochastic objective to minimize
 ``0.5 x_1 + 0.5 x_2 + \mathbb{E}_\xi [y^2 - y]``:
-```jldoctest obj; setup = :(using InfiniteOpt, JuMP, Distributions; model = InfiniteModel())
+```jldoctest obj; setup = :(using InfiniteOpt, Distributions; model = InfiniteModel())
 julia> @infinite_parameter(model, ξ in Normal())
 ξ
 

--- a/docs/src/guide/optimize.md
+++ b/docs/src/guide/optimize.md
@@ -19,7 +19,7 @@ method required to optimize an `InfiniteModel`. This is exactly analogous
 to that of any `JuMP.Model` and is designed to provide a similar user experience.
 Let's first define an `InfiniteModel` with an appropriate optimizer:
 ```jldoctest optimize
-julia> using InfiniteOpt, JuMP, Ipopt;
+julia> using InfiniteOpt, Ipopt;
 
 julia> model = InfiniteModel(Ipopt.Optimizer);
 
@@ -57,7 +57,7 @@ solution is explained on the [Results](@ref) page.
 
 If no optimizer has been specified for the `InfiniteModel`, one can be provided
 via [`set_optimizer`](@ref):
-```jldoctest; setup = :(using InfiniteOpt, JuMP, Ipopt; model = InfiniteModel())
+```jldoctest; setup = :(using InfiniteOpt, Ipopt; model = InfiniteModel())
 julia> set_optimizer(model, Ipopt.Optimizer)
 ```
 

--- a/docs/src/guide/parameter.md
+++ b/docs/src/guide/parameter.md
@@ -19,7 +19,7 @@ First, we need to initialize and add infinite parameters to our `InfiniteModel`.
 This can be accomplished using [`@infinite_parameter`](@ref). For example, let's
 define a parameter for time in a time interval from 0 to 10:
 ```jldoctest basic
-julia> using InfiniteOpt, JuMP
+julia> using InfiniteOpt
 
 julia> model = InfiniteModel();
 
@@ -66,7 +66,7 @@ julia> supports(t)
 Here only 4 supports are specified for the sake of example. Alternatively, we
 could have initialized the parameter and added supports in just one step using
 the `supports` keyword argument:
-```jldoctest; setup = :(using InfiniteOpt, JuMP; model = InfiniteModel())
+```jldoctest; setup = :(using InfiniteOpt; model = InfiniteModel())
 julia> @infinite_parameter(model, t in [0, 10], supports = [0., 2.5, 7.5, 10.])
 t
 ```
@@ -304,7 +304,7 @@ true. However, we can explicitly dictate the kind of containers we want to hold
 the defined parameters using the keyword `container`. For example, we use
 `SparseAxisArray` from the `JuMP` package for the space
 parameter `x`:
-```jldoctest; setup = :(using InfiniteOpt, JuMP; model= InfiniteModel())
+```jldoctest; setup = :(using InfiniteOpt; model= InfiniteModel())
 julia> @infinite_parameter(model, x[1:3] in [0, 1], container = SparseAxisArray)
 JuMP.Containers.SparseAxisArray{GeneralVariableRef,1,Tuple{Int64}} with 3 entries:
   [3]  =  x[3]
@@ -339,7 +339,7 @@ consider the position parameter `x` in a 3D space. Say `x` is bounded in `[0, 1]
 in all three dimensions, and the user wants to generate grid points with interval
 `0.5` in all three dimensions.
 In this case, we can define `x` in the following way:
-```jldoctest; setup = :(using InfiniteOpt, JuMP; model= InfiniteModel())
+```jldoctest; setup = :(using InfiniteOpt; model= InfiniteModel())
 julia> pts = collect(range(0, stop = 1, length = 3))
 3-element Array{Float64,1}:
  0.0
@@ -368,7 +368,7 @@ As mentioned above, we can define anonymous parameters using keyword arguments
 in the macro [`@infinite_parameter`](@ref). For instance, we can create an
 anonymous position parameter in a 3D space, referred to by a list of [`GeneralVariableRef`](@ref)
 called `x`:
-```jldoctest; setup = :(using InfiniteOpt, JuMP; model = InfiniteModel())
+```jldoctest; setup = :(using InfiniteOpt; model = InfiniteModel())
 julia> x = @infinite_parameter(model, [1:3], lower_bound = 0, upper_bound = 1)
 3-element Array{GeneralVariableRef,1}:
  noname
@@ -426,7 +426,7 @@ As mentioned above, the users can choose to specify the set either in the
 second argument (nonanonymous parameter definition only), or in the keyword
 arguments. However, the users cannot do both at the same time. The macro will
 check this behavior and throw an error if this happens. For example,
-```jldoctest; setup = :(using InfiniteOpt, JuMP; model = InfiniteModel())
+```jldoctest; setup = :(using InfiniteOpt; model = InfiniteModel())
 julia> @infinite_parameter(model,  y in [0, 1], lower_bound = 0, upper_bound = 1)
 ERROR: LoadError: At none:1: `@infinite_parameter(model, y in [0, 1], lower_bound = 0, upper_bound = 1)`: Cannot specify parameter lower_bound twice
 [...]
@@ -603,7 +603,7 @@ parameter is in an [`IntervalSet`](@ref), then we generate an array of supports
 that are uniformly distributed along the interval, including the two ends. For
 example, consider a 3D position parameter `x` distributed in the unit cube
 `[0, 1]`. We can generate supports for that point in the following way:
-```jldoctest supp_gen_defined; setup = :(using InfiniteOpt, JuMP, Distributions, Random; Random.seed!(0); model = InfiniteModel())
+```jldoctest supp_gen_defined; setup = :(using InfiniteOpt, Distributions, Random; Random.seed!(0); model = InfiniteModel())
 julia> @infinite_parameter(model, x[1:3] in [0, 1], independent = true);
 
 julia> fill_in_supports!.(x, num_supports = 3);
@@ -667,7 +667,7 @@ functions for accessing parameter information.
 Once a (possibly large-scale) `InfiniteModel` is built, the users might want to
 check if an infinite parameter is actually used in any way. This could be
 checked by [`is_used`](@ref) function as follows:
-```jldoctest param_queries; setup = :(using InfiniteOpt, JuMP; model = InfiniteModel())
+```jldoctest param_queries; setup = :(using InfiniteOpt; model = InfiniteModel())
 julia> @infinite_parameter(model, x in [0, 1])
 x
 

--- a/docs/src/guide/result.md
+++ b/docs/src/guide/result.md
@@ -13,7 +13,7 @@ walk through the use of these result query functions.
 ## Basic Usage
 Let's revisit the example from the optimization page to get us started:
 ```jldoctest results
-julia> using InfiniteOpt, JuMP, Ipopt;
+julia> using InfiniteOpt, Ipopt;
 
 julia> model = InfiniteModel(Ipopt.Optimizer);
 

--- a/docs/src/guide/sets.md
+++ b/docs/src/guide/sets.md
@@ -112,7 +112,7 @@ similar to how one queries the bounds of a `JuMP` variable. Thus, the functions
 [`JuMP.has_lower_bound`](@ref), [`JuMP.has_upper_bound`](@ref), [`JuMP.lower_bound`](@ref), [`JuMP.upper_bound`](@ref) 
 are all applicable to infinite sets mentioned above. For example, for an `IntervalSet`
 `[-2, 2]` we can query the bound information as follows:
-```jldoctest; setup = :(using InfiniteOpt, JuMP)
+```jldoctest; setup = :(using InfiniteOpt)
 julia> set = IntervalSet(-2, 2);
 
 julia> has_lower_bound(set)
@@ -130,7 +130,7 @@ julia> upper_bound(set)
 In addition, we can also apply [`JuMP.set_lower_bound`](@ref) and [`JuMP.set_upper_bound`](@ref) 
 to `IntervalSet`s to generate a new set with updated bounds. Note that this will not modify the
 original set. For example, we can change the bounds of the set `[-2, 2]` as follows:
-```jldoctest; setup = :(using InfiniteOpt, JuMP; set = IntervalSet(-2, 2))
+```jldoctest; setup = :(using InfiniteOpt; set = IntervalSet(-2, 2))
 julia> set_lower_bound(set, -1)
 [-1, 2]
 

--- a/docs/src/guide/transcribe.md
+++ b/docs/src/guide/transcribe.md
@@ -30,7 +30,7 @@ accomplished via [`build_optimizer_model!`](@ref). To illustrate how this is don
 let's first define a basic infinite
 model with a simple support structure for the sake of example:
 ```jldoctest transcribe
-julia> using InfiniteOpt, JuMP
+julia> using InfiniteOpt
 
 julia> inf_model = InfiniteModel();
 

--- a/docs/src/guide/variable.md
+++ b/docs/src/guide/variable.md
@@ -40,7 +40,7 @@ respective variable type.
 Let's first setup a simple space-time model with infinite parameters time `t` and
 spatial position `x`:
 ```jldoctest var_basic
-julia> using InfiniteOpt, JuMP
+julia> using InfiniteOpt
 
 julia> model = InfiniteModel();
 
@@ -163,7 +163,7 @@ The `JuMP.VariableInfo` data structure stores the following variable information
 - `binary`: Specifies `Bool` if it is binary
 - `integer`: Specifies `Bool` if it is integer.
 Thus, the user specifies this information to prepare such an object:
-```jldoctest genvar_define; setup = :(using InfiniteOpt, JuMP; model = InfiniteModel())
+```jldoctest genvar_define; setup = :(using InfiniteOpt; model = InfiniteModel())
 julia> info = VariableInfo(true, 0., true, 42., false, 0., false, 0., false, true)
 VariableInfo{Float64,Float64,Float64,Float64}(true, 0.0, true, 42.0, false, 0.0, false, 0.0, false, true)
 ```
@@ -225,7 +225,7 @@ these pertain to `JuMP`-like features). To illustrate this via example, let's
 setup a model with a variety of infinite parameters ``t \in [0,10]``,
 ``x \in [-1, 1]^3``, and ``\xi \in \mathcal{N}(0, 1)``:
 ```jldoctest var_macro
-julia> using InfiniteOpt, JuMP, Distributions
+julia> using InfiniteOpt, Distributions
 
 julia> model = InfiniteModel();
 
@@ -724,7 +724,7 @@ is invoked any bound/type constraints associated with the variable will be remov
 and it will be removed from any other constraints, measures, and/or objectives.
 For example, if we delete `y(t, x)` it will be removed along with its bounds and
 the point variable `y0` will also be removed since it is a dependent:
-```jldoctest; setup = :(using InfiniteOpt, JuMP; model = InfiniteModel(); @finite_variable(model, y))
+```jldoctest; setup = :(using InfiniteOpt; model = InfiniteModel(); @finite_variable(model, y))
 julia> delete(model, y)
 ```
 

--- a/docs/src/quick_start.md
+++ b/docs/src/quick_start.md
@@ -54,7 +54,7 @@ The first thing we need to do is initialize our `InfiniteModel` and assign an
 appropriate optimizer that will be used to solve its transcripted variant. For our 
 little example let's choose to use Ipopt:
 ```jldoctest quick
-julia> using InfiniteOpt, JuMP, Distributions, Ipopt;
+julia> using InfiniteOpt, Distributions, Ipopt;
 
 julia> model = InfiniteModel(Ipopt.Optimizer)
 An InfiniteOpt Model
@@ -258,7 +258,7 @@ Please see the [Results](@ref) page for more information.
 ## Summary Script 
 The example used in the sections above is summarized in the script below:
 ```julia
-using InfiniteOpt, JuMP, Distributions, Ipopt
+using InfiniteOpt, Distributions, Ipopt
 
 # DEFINE THE PROBLEM CONSTANTS
 μ = 1; σ = 0.2

--- a/examples/3node_flexible_design.jl
+++ b/examples/3node_flexible_design.jl
@@ -5,7 +5,7 @@ programming approach for the design of flexible systems. Computers & Chemical
 Engineering. 2019 Sep 2;128:69-76.
 """
 
-using InfiniteOpt, JuMP, Clp, Distributions
+using InfiniteOpt, Clp, Distributions
 
 # Set the covariance matrix for the uncertain parameters
 θ_nom = [0.; 60.; 10.]

--- a/examples/hovercraft.jl
+++ b/examples/hovercraft.jl
@@ -3,7 +3,7 @@ Dynamic path planning problem of hovercraft trying to minimize thrust usage
 to hit all the waypoints at the alotted target times.
 """
 
-using InfiniteOpt, JuMP, Ipopt, PyPlot
+using InfiniteOpt, Ipopt, PyPlot
 
 # Waypoints
 xw = [1 4 6 1; 1 3 0 1] # positions

--- a/src/InfiniteOpt.jl
+++ b/src/InfiniteOpt.jl
@@ -1,15 +1,16 @@
 module InfiniteOpt
 
+# Import and export JuMP 
+import Reexport 
+Reexport.@reexport using JuMP
+
 # Import the necessary packages.
-import JuMP
 import MathOptInterface
 import Distributions
 import DataStructures
 import FastGaussQuadrature
 
-# Make useful aliases
-const MOI = MathOptInterface
-const MOIU = MOI.Utilities
+# Make useful aliases (note we get MOI and MOIU from JuMP)
 const JuMPC = JuMP.Containers
 const MOIUC = MOIU.CleverDicts
 
@@ -31,16 +32,9 @@ include("expressions.jl")
 include("macro_utilities.jl")
 include("measures.jl")
 
-# Import MeasureToolbox
+# Import and export MeasureToolbox
 include("MeasureToolbox/MeasureToolbox.jl")
-using .MeasureToolbox: Automatic, UniTrapezoid, UniMCSampling,
-UniIndepMCSampling, Quadrature, GaussHermite, GaussLegendre, GaussRadau, 
-GaussLobatto, GaussJacobi, GaussLaguerre, GaussChebyshev, FEGaussLobatto,
-MultiMCSampling, MultiIndepMCSampling, uni_integral_defaults,
-set_uni_integral_defaults, integral, multi_integral_defaults,
-clear_uni_integral_defaults, clear_multi_integral_defaults,
-set_multi_integral_defaults, expect, support_sum, @integral, @expect, @support_sum,
-generate_integral_data, 𝔼, ∫, @𝔼, @∫, InternalGaussLobatto
+Reexport.@reexport using .MeasureToolbox
 
 # Import more methods
 include("derivatives.jl")
@@ -55,137 +49,23 @@ include("show.jl")
 include("utilities.jl")
 include("general_variables.jl")
 
-# Import TranscriptionOpt
+# Import and export TranscriptionOpt
 include("TranscriptionOpt/TranscriptionOpt.jl")
-using .TranscriptionOpt
+Reexport.@reexport using .TranscriptionOpt
 
-# Export core datatypes
-export AbstractDataObject, InfiniteModel
+# Define additional stuff that should not be exported
+const _EXCLUDE_SYMBOLS = [Symbol(@__MODULE__), :eval, :include]
 
-# Export deprecated stuff
-export @hold_variable
-
-# Export macros
-export @independent_parameter, @dependent_parameters, @infinite_parameter,
-@finite_parameter, @infinite_variable, @point_variable, @finite_variable, 
-@infinite_parameter, @BDconstraint, @set_parameter_bounds, @add_parameter_bounds, 
-@measure, @integral, @expect, @support_sum, @deriv, @derivative_variable, @∂, @𝔼, 
-@∫, @parameter_function
-
-# Export variable types 
-export InfOptVariableType, Infinite, Point, Finite, Deriv
-
-# Export index types
-export AbstractInfOptIndex, ObjectIndex, IndependentParameterIndex,
-DependentParametersIndex, DependentParameterIndex, FiniteParameterIndex,
-InfiniteVariableIndex, PointVariableIndex, SemiInfiniteVariableIndex,
-FiniteVariableIndex, MeasureIndex, ConstraintIndex, InfiniteParameterIndex,
-FiniteIndex, DerivativeIndex, ParameterFunctionIndex
-
-# Export infinite set types
-export AbstractInfiniteSet, InfiniteScalarSet, InfiniteArraySet, IntervalSet,
-UniDistributionSet, MultiDistributionSet, CollectionSet, AbstractSupportLabel, 
-PublicLabel, InternalLabel, SampleLabel, UserDefined, MCSample, UniformGrid, 
-Mixture, All, WeightedSample, UniqueMeasure
-
-# Export infinite set methods
-export collection_sets, supports_in_set, generate_support_values
-
-# Export parameter datatypes
-export InfOptParameter, ScalarParameter, IndependentParameter, FiniteParameter,
-DependentParameters, ScalarParameterData, MultiParameterData,
-IndependentParameterRef, DependentParameterRef, FiniteParameterRef,
-ScalarParameterRef, InfiniteParameter, AbstractGenerativeInfo, 
-NoGenerativeSupports, UniformGenerativeInfo
-
-# Export parameter methods
-export build_parameter, add_parameter, add_parameters,
-infinite_set, set_infinite_set, parameter_by_name, num_parameters,
-all_parameters, num_supports, has_supports,
-set_supports, add_supports, delete_supports, supports, used_by_constraint,
-used_by_measure, used_by_infinite_variable, is_used, generate_and_add_supports!,
-significant_digits, parameter_value, used_by_derivative, derivative_method, 
-set_derivative_method, set_all_derivative_methods, has_internal_supports, 
-has_generative_supports, has_derivative_constraints, used_by_parameter_function,
-generative_support_info, make_generative_supports, add_generative_supports
-
-# Export the paramter function datatypes and methods 
-export ParameterFunction, ParameterFunctionData, ParameterFunctionRef,
-build_parameter_function, add_parameter_function, raw_function, parameter_function,
-call_function
-
-# Export variable datatypes
-export InfOptVariable, InfiniteVariable, SemiInfiniteVariable,
-PointVariable, FiniteVariable, ParameterBounds, VariableData, GeneralVariableRef,
-DispatchVariableRef, InfiniteVariableRef, SemiInfiniteVariableRef, FiniteRef, 
-PointVariableRef, FiniteVariableRef, DecisionVariableRef, UserDecisionVariableRef
-
-# Export variable methods
-export used_by_objective, infinite_variable_ref, parameter_refs,
-used_by_point_variable, parameter_values,
-eval_supports, used_by_semi_infinite_variable, has_parameter_bounds, parameter_bounds,
-set_parameter_bounds, add_parameter_bounds, delete_parameter_bounds,
-parameter_list, raw_parameter_refs, raw_parameter_values,
-intervals, dispatch_variable_ref, internal_semi_infinite_variable, start_value_function,
-set_start_value_function, reset_start_value_function
-
-# Export derivative datatypes 
-export Derivative, DerivativeRef, AbstractDerivativeMethod, 
-GenerativeDerivativeMethod, NonGenerativeDerivativeMethod, OrthogonalCollocation,
-FiniteDifference, FDTechnique, Forward, Central, Backward
-
-# Export derivative methods 
-export build_derivative, add_derivative, derivative_argument, operator_parameter,
-deriv, evaluate_derivative, evaluate, evaluate_all_derivatives!, num_derivatives, 
-all_derivatives, derivative_constraints, delete_derivative_constraints, ∂
-
-# Export measure datatypes
-export AbstractMeasureData, DiscreteMeasureData, FunctionalDiscreteMeasureData,
-Measure, MeasureData, MeasureRef
-
-# Export measure methods
-export default_weight, support_label, coefficient_function, coefficients,
-weight_function, build_measure, min_num_supports, add_measure, measure_function,
-measure_data, is_analytic, measure, num_measures, all_measures,
-add_supports_to_parameters, measure_data_in_finite_var_bounds, make_point_variable_ref,
-make_semi_infinite_variable_ref, add_measure_variable, delete_internal_semi_infinite_variable,
-delete_semi_infinite_variable, expand, expand_all_measures!, expand_measure
-
-# Export the measure toolbox functions and datatypes
-export Automatic, UniTrapezoid, UniMCSampling, UniIndepMCSampling, Quadrature,
-GaussRadau, GaussHermite, GaussLegendre, GaussRadau, GaussLobatto, FEGaussLobatto,
-GaussJacobi, GaussChebyshev, GaussLaguerre, MultiMCSampling, MultiIndepMCSampling, 
-uni_integral_defaults, set_uni_integral_defaults, clear_uni_integral_defaults,
-integral, multi_integral_defaults, set_multi_integral_defaults, 
-clear_multi_integral_defaults, expect, support_sum,
-generate_integral_data, 𝔼, ∫, InternalGaussLobatto
-
-# Export objective methods
-export objective_has_measures
-
-# Export constraint datatypes
-export BoundedScalarConstraint, ConstraintData, InfOptConstraintRef
-
-# Export constraint methods
-export original_parameter_bounds
-
-# Export transcription datatypes
-export TranscriptionData, TranscriptionModel
-
-# Export transcription methods
-export is_transcription_model, transcription_data, transcription_variable,
-transcription_constraint, transcription_model, transcription_expression
-
-# Export optimize methods
-export optimizer_model, set_optimizer_model, optimizer_model_ready,
-set_optimizer_model_ready, build_optimizer_model!, optimizer_model_key,
-optimizer_model_variable, optimizer_model_constraint, constraint_parameter_refs,
-clear_optimizer_model_build!, optimizer_model_expression
-
-# Export results methods 
-export InfOptSensitivityReport
-
-# Export support generation and fill-in methods
-export fill_in_supports!, generate_supports
+# Following JuMP, export everything that doesn't start with a _ 
+for sym in names(@__MODULE__, all = true)
+    sym_string = string(sym)
+    if sym in _EXCLUDE_SYMBOLS || startswith(sym_string, "_") || startswith(sym_string, "@_")
+        continue
+    end
+    if !(Base.isidentifier(sym) || (startswith(sym_string, "@") && Base.isidentifier(sym_string[2:end])))
+        continue
+    end
+    @eval export $sym
+end
 
 end # module

--- a/src/MeasureToolbox/MeasureToolbox.jl
+++ b/src/MeasureToolbox/MeasureToolbox.jl
@@ -12,12 +12,19 @@ include("integrals.jl")
 include("expectations.jl")
 include("support_sums.jl")
 
+# Export DataTypes
 export Automatic, UniTrapezoid, UniMCSampling, UniIndepMCSampling, Quadrature,
 GaussRadau, GaussHermite, GaussLegendre, GaussRadau, GaussLobatto, FEGaussLobatto,
 GaussJacobi, GaussChebyshev, GaussLaguerre, MultiMCSampling, MultiIndepMCSampling, 
-uni_integral_defaults, set_uni_integral_defaults, clear_uni_integral_defaults,
-integral, multi_integral_defaults, set_multi_integral_defaults, 
-clear_multi_integral_defaults, expect, support_sum,
-generate_integral_data, 𝔼, ∫, InternalGaussLobatto
+InternalGaussLobatto
+
+# Export methods
+export uni_integral_defaults, set_uni_integral_defaults, 
+clear_uni_integral_defaults, integral, multi_integral_defaults, 
+set_multi_integral_defaults, clear_multi_integral_defaults, expect, support_sum,
+generate_integral_data, 𝔼, ∫
+
+# Export macros
+export @expect, @𝔼, @support_sum, @integral, @∫
 
 end # end module

--- a/src/MeasureToolbox/MeasureToolbox.jl
+++ b/src/MeasureToolbox/MeasureToolbox.jl
@@ -12,4 +12,12 @@ include("integrals.jl")
 include("expectations.jl")
 include("support_sums.jl")
 
+export Automatic, UniTrapezoid, UniMCSampling, UniIndepMCSampling, Quadrature,
+GaussRadau, GaussHermite, GaussLegendre, GaussRadau, GaussLobatto, FEGaussLobatto,
+GaussJacobi, GaussChebyshev, GaussLaguerre, MultiMCSampling, MultiIndepMCSampling, 
+uni_integral_defaults, set_uni_integral_defaults, clear_uni_integral_defaults,
+integral, multi_integral_defaults, set_multi_integral_defaults, 
+clear_multi_integral_defaults, expect, support_sum,
+generate_integral_data, 𝔼, ∫, InternalGaussLobatto
+
 end # end module


### PR DESCRIPTION
Closes #103 and cleans up the exporting structure of InfiniteOpt using `Rexport.@reexport`.
