### PR TITLE
Discourage Finite Models

### DIFF
--- a/docs/src/guide/model.md
+++ b/docs/src/guide/model.md
@@ -11,6 +11,12 @@ measures, objective, constraints, and all other data used in `InfiniteOpt`. This
 differs from `JuMP` models which store such information in a `MathOptInterface`
 model backend.
 
+!!! note 
+    `InfiniteOpt`'s `InfiniteModel`s are intended to be used for 
+    infinite-dimensional optimization problems. Finite problems (e.g., 
+    directly modeling a discrete time model) should instead be modeled using 
+    `Model`'s in [`JuMP`](https://jump.dev/JuMP.jl/stable/).
+
 ## Basic Usage
 Infinite models can be initialized with no arguments by default:
 ```jldoctest

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -30,6 +30,11 @@ include:
 - Measures (e.g., ``\int_{t \in \mathcal{D}_t}y(t,x) dt``, ``\mathbb{E}[y(\xi)]``)
 - More
 
+!!! note 
+    `InfiniteOpt` is intended to be used for infinite-dimensional optimization 
+    problems. Finite problems (e.g., directly modeling a discrete time model) 
+    should instead be modeled using [`JuMP`](https://jump.dev/JuMP.jl/stable/).
+
 Moreover, `InfiniteOpt` decouples the infinite-dimensional formulations from the 
 finite transformations typically used to solve them. This readily enables diverse 
 techniques be used to solve these types of problems. By default, we employ 

--- a/src/TranscriptionOpt/transcribe.jl
+++ b/src/TranscriptionOpt/transcribe.jl
@@ -872,8 +872,11 @@ function build_transcription_model!(
     set_parameter_supports(trans_model, inf_model)
     # check that there isn't a crazy amount of supports from taking the product
     supps = parameter_supports(trans_model)
-    num_supps = prod(length, supps)
-    if check_support_dims && length(supps) > 1 && num_supps > 15000 # NOTE this is an arbitrary cutoff
+    num_supps = isempty(supps) ? 0 : prod(length, supps)
+    if iszero(num_supps)
+        @warn("Finite models (i.e., `InfiniteModel`s with no infinite " * 
+              "parameters) should be modeled directly via a `Model` in JuMP.jl.")
+    elseif check_support_dims && length(supps) > 1 && num_supps > 15000 # NOTE this is an arbitrary cutoff
         @warn("Due to necessarily considering the combinatorics of independent " *
               "parameter supports, the model will be transcripted over up to $(num_supps) " *
               "supports (if any constraint uses all the infinite parameters) "  *

--- a/src/TranscriptionOpt/transcribe.jl
+++ b/src/TranscriptionOpt/transcribe.jl
@@ -873,10 +873,7 @@ function build_transcription_model!(
     # check that there isn't a crazy amount of supports from taking the product
     supps = parameter_supports(trans_model)
     num_supps = isempty(supps) ? 0 : prod(length, supps)
-    if iszero(num_supps)
-        @warn("Finite models (i.e., `InfiniteModel`s with no infinite " * 
-              "parameters) should be modeled directly via a `Model` in JuMP.jl.")
-    elseif check_support_dims && length(supps) > 1 && num_supps > 15000 # NOTE this is an arbitrary cutoff
+    if check_support_dims && length(supps) > 1 && num_supps > 15000 # NOTE this is an arbitrary cutoff
         @warn("Due to necessarily considering the combinatorics of independent " *
               "parameter supports, the model will be transcripted over up to $(num_supps) " *
               "supports (if any constraint uses all the infinite parameters) "  *

--- a/src/optimize.jl
+++ b/src/optimize.jl
@@ -521,9 +521,13 @@ true
 ```
 """
 function build_optimizer_model!(model::InfiniteModel; kwargs...)
-  key = optimizer_model_key(model)
-  build_optimizer_model!(model, Val(key); kwargs...)
-  return
+    if num_parameters(model, InfiniteParameter) == 0
+        @warn("Finite models (i.e., `InfiniteModel`s with no infinite " * 
+              "parameters) should be modeled directly via a `Model` in JuMP.jl.")
+    end
+    key = optimizer_model_key(model)
+    build_optimizer_model!(model, Val(key); kwargs...)
+    return
 end
 
 ################################################################################

--- a/test/TranscriptionOpt/transcribe.jl
+++ b/test/TranscriptionOpt/transcribe.jl
@@ -501,7 +501,8 @@ end
     @variable(m, y >= 0)
     @objective(m, Min, y)
     tm = transcription_model(m)
-    warn = "Finite models (i.e., `InfiniteModel`s with no infinite " * 
-           "parameters) should be modeled directly via a `Model` in JuMP.jl."
-    @test_logs (:warn, warn) IOTO.build_transcription_model!(tm, m)
+    @test IOTO.build_transcription_model!(tm, m) isa Nothing 
+    @test transcription_variable(y) isa VariableRef 
+    @test lower_bound(transcription_variable(y)) == 0
+    @test objective_sense(tm) == MOI.MIN_SENSE
 end

--- a/test/TranscriptionOpt/transcribe.jl
+++ b/test/TranscriptionOpt/transcribe.jl
@@ -495,4 +495,13 @@ end
     @test transcription_constraint(FixRef(y)) isa Vector{ConstraintRef}
     @test transcription_constraint(BinaryRef(y)) isa Vector{ConstraintRef}
     @test transcription_constraint(UpperBoundRef(d1)) == UpperBoundRef.(d1t)
+
+    # test a finite model 
+    m = InfiniteModel()
+    @variable(m, y >= 0)
+    @objective(m, Min, y)
+    tm = transcription_model(m)
+    warn = "Finite models (i.e., `InfiniteModel`s with no infinite " * 
+           "parameters) should be modeled directly via a `Model` in JuMP.jl."
+    @test_logs (:warn, warn) IOTO.build_transcription_model!(tm, m)
 end

--- a/test/optimizer.jl
+++ b/test/optimizer.jl
@@ -29,6 +29,13 @@
     @test isa(build_optimizer_model!(m), Nothing)
     @test optimizer_model_ready(m)
     @test num_variables(optimizer_model(m)) == 14
+    # test finite model
+    m = InfiniteModel()
+    @variable(m, y >= 0)
+    @objective(m, Min, y)
+    warn = "Finite models (i.e., `InfiniteModel`s with no infinite " * 
+           "parameters) should be modeled directly via a `Model` in JuMP.jl."
+    @test_logs (:warn, warn) build_optimizer_model!(m)
 end
 
 # Test optimizer model querying methods


### PR DESCRIPTION
Before the support check at transcription errored with finite models:
```julia
m = InfiniteModel()
@variable(m, y >= 0)
build_optimizer_model!(m)
```
```julia
ERROR: ArgumentError: reducing over an empty collection is not allowed
Stacktrace:
  [1] _empty_reduce_error()
    @ Base .\reduce.jl:299
  [2] mapreduce_empty(f::Function, op::Base.BottomRF{typeof(Base.mul_prod)}, T::Type)
    @ Base .\reduce.jl:342
  [3] reduce_empty(op::Base.MappingRF{typeof(length), Base.BottomRF{typeof(Base.mul_prod)}}, #unused#::Type{Union{}})
    @ Base .\reduce.jl:329
  [4] reduce_empty_iter
    @ .\reduce.jl:355 [inlined]
  [5] reduce_empty_iter
    @ .\reduce.jl:354 [inlined]
  [6] foldl_impl(op::Base.MappingRF{typeof(length), Base.BottomRF{typeof(Base.mul_prod)}}, nt::Base._InitialValue, itr::Tuple{})
    @ Base .\reduce.jl:49
  [7] mapfoldl_impl(f::typeof(length), op::typeof(Base.mul_prod), nt::Base._InitialValue, itr::Tuple{})
    @ Base .\reduce.jl:44
  [8] mapfoldl(f::Function, op::Function, itr::Tuple{}; init::Base._InitialValue)
    @ Base .\reduce.jl:160
  [9] mapfoldl
    @ .\reduce.jl:160 [inlined]
 [10] #mapreduce#218
    @ .\reduce.jl:287 [inlined]
 [11] mapreduce
    @ .\reduce.jl:287 [inlined]
 [12] #prod#224
    @ .\reduce.jl:555 [inlined]
 [13] prod(f::Function, a::Tuple{})
    @ Base .\reduce.jl:555
 [14] build_transcription_model!(trans_model::Model, inf_model::InfiniteModel; check_support_dims::Bool)
    @ InfiniteOpt.TranscriptionOpt ~\src\TranscriptionOpt\transcribe.jl:875
 [15] #build_optimizer_model!#95
    @ ~\src\TranscriptionOpt\optimize.jl:34 [inlined]
 [16] build_optimizer_model!
    @ ~\src\TranscriptionOpt\optimize.jl:32 [inlined]
 [17] build_optimizer_model!(model::InfiniteModel; kwargs::Base.Iterators.Pairs{Union{}, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
    @ ~\InfiniteOpt\8U5IK\src\optimize.jl:525
 [18] build_optimizer_model!
    @ ~\InfiniteOpt\8U5IK\src\optimize.jl:524 [inlined]
 [19] #optimize!#386
    @ ~\InfiniteOpt\8U5IK\src\optimize.jl:921 [inlined]
 [20] optimize!(model::InfiniteModel)
    @ ~\InfiniteOpt\8U5IK\src\optimize.jl:920
 [21] top-level scope
    @ REPL[107]:1
```

Now we have the following warning and it works (also added docs to discourage doing so):
```julia 
m = InfiniteModel()
@variable(m, y >= 0)
build_optimizer_model!(m)
```
```julia
┌ Warning: Finite models (i.e., `InfiniteModel`s with no infinite parameters) should be modeled directly via a `Model` in JuMP.jl.
└ @ InfiniteOpt ~\InfiniteOpt\src\optimize.jl:525
```