### PR TITLE
Prevent Redundant Definition

### DIFF
--- a/docs/src/develop/extensions.md
+++ b/docs/src/develop/extensions.md
@@ -575,7 +575,7 @@ moreover infinite models using this new type can be optimized. Let's try
 expanding the measure we already defined:
 ```jldoctest measure_data
 julia> expand(mref)
-2 y(-0.556026876146)² + 2 z*y(-0.556026876146) - 2 y(-0.556026876146)² - 2 y(-0.44438335711)*y(-0.556026876146) - 2 z*y(-0.556026876146) + 0 z² - y(-0.556026876146)*z - y(-0.44438335711)*z + 0.5 y(-0.556026876146)² + 0.5 y(-0.556026876146)*y(-0.44438335711) + 0.5 y(-0.556026876146)*z + 0.5 y(-0.44438335711)*y(-0.556026876146) + 0.5 y(-0.44438335711)² + 0.5 y(-0.44438335711)*z + 0.5 z*y(-0.556026876146) + 0.5 z*y(-0.44438335711) + 2 y(-0.44438335711)² + 2 z*y(-0.44438335711) - 2 y(-0.556026876146)*y(-0.44438335711) - 2 y(-0.44438335711)² - 2 z*y(-0.44438335711) - y(-0.556026876146)*z - y(-0.44438335711)*z + 0.5 y(-0.556026876146)² + 0.5 y(-0.556026876146)*y(-0.44438335711) + 0.5 y(-0.556026876146)*z + 0.5 y(-0.44438335711)*y(-0.556026876146) + 0.5 y(-0.44438335711)² + 0.5 y(-0.44438335711)*z + 0.5 z*y(-0.556026876146) + 0.5 z*y(-0.44438335711)
+y(-0.556026876146)² + 0 z*y(-0.556026876146) - 2 y(-0.44438335711)*y(-0.556026876146) + 0 z² + 0 z*y(-0.44438335711) + y(-0.44438335711)²
 ```
 
 Finally, as per recommendation let's make a wrapper method to make defining 
@@ -613,7 +613,7 @@ for `expr`.
 Now let's use our constructor to repeat the above measure example:
 ```jldoctest measure_data
 julia> expand(variance(2y + z, xi, use_existing = true))
-2 y(-0.556026876146)² + 2 z*y(-0.556026876146) - 2 y(-0.556026876146)² - 2 y(-0.44438335711)*y(-0.556026876146) - 2 z*y(-0.556026876146) + 0 z² - y(-0.556026876146)*z - y(-0.44438335711)*z + 0.5 y(-0.556026876146)² + 0.5 y(-0.556026876146)*y(-0.44438335711) + 0.5 y(-0.556026876146)*z + 0.5 y(-0.44438335711)*y(-0.556026876146) + 0.5 y(-0.44438335711)² + 0.5 y(-0.44438335711)*z + 0.5 z*y(-0.556026876146) + 0.5 z*y(-0.44438335711) + 2 y(-0.44438335711)² + 2 z*y(-0.44438335711) - 2 y(-0.556026876146)*y(-0.44438335711) - 2 y(-0.44438335711)² - 2 z*y(-0.44438335711) - y(-0.556026876146)*z - y(-0.44438335711)*z + 0.5 y(-0.556026876146)² + 0.5 y(-0.556026876146)*y(-0.44438335711) + 0.5 y(-0.556026876146)*z + 0.5 y(-0.44438335711)*y(-0.556026876146) + 0.5 y(-0.44438335711)² + 0.5 y(-0.44438335711)*z + 0.5 z*y(-0.556026876146) + 0.5 z*y(-0.44438335711)
+y(-0.556026876146)² + 0 z*y(-0.556026876146) - 2 y(-0.44438335711)*y(-0.556026876146) + 0 z² + 0 z*y(-0.44438335711) + y(-0.44438335711)²
 ```
 
 We have done it! Now go and extend away!
@@ -715,11 +715,9 @@ extended using the following steps:
     - [`InfiniteOpt.map_optimizer_index`](@ref) (enables `JuMP.optimizer_index`)
     - [`InfiniteOpt.map_dual`](@ref) (enables `JuMP.dual`)
     - [`InfiniteOpt.map_shadow_price`](@ref) (enables `JuMP.shadow_price`)
-11. Extend [`InfiniteOpt.add_measure_variable`](@ref) to use 
-    [`expand_measure`](@ref) without modifying the infinite model
-12. Extend [`InfiniteOpt.delete_semi_infinite_variable`](@ref) to use 
-    [`expand_measure`](@ref) without modifying the infinite model and delete 
-    unneeded semi-infinite variables.
+11. Extend [`InfiniteOpt.add_point_variable`](@ref) and 
+    [`InfiniteOpt.add_semi_infinite_variable`](@ref) to use 
+    [`expand_measure`](@ref) without modifying the infinite model.
 
 For the sake of example, let's suppose we want to define a reformulation method 
 for `InfiniteModel`s that are 2-stage stochastic programs (i.e., only 

--- a/docs/src/examples/Optimal Control/consumption_savings.jl
+++ b/docs/src/examples/Optimal Control/consumption_savings.jl
@@ -58,8 +58,8 @@ m = InfiniteModel(opt)
 @objective(m, Max, integral(u(c), t, weight_func = discount))    
 
 # Set the initial/terminal conditions:
-@constraint(m, B == B0, DomainRestrictions(t => 0))                    
-@constraint(m, B == 0, DomainRestrictions(t => T))                     
+@constraint(m, B(0) == B0)                    
+@constraint(m, B(T) == 0)                     
 
 # Set the budget constraint:
 @constraint(m, c1, deriv(B, t) == BC(B, c; r=r))

--- a/docs/src/examples/Optimal Control/hovercraft.jl
+++ b/docs/src/examples/Optimal Control/hovercraft.jl
@@ -47,14 +47,14 @@ end)
 @objective(m, Min, ∫(u[1]^2 + u[2]^2, t))
 
 # Set the initial conditions with respect to the velocity:
-@constraint(m, [i = 1:2], v[i] == 0, DomainRestrictions(t => 0))
+@constraint(m, [i = 1:2], v[i](0) == 0)
 
 # Define the point physics ODEs which serve as our system model:
 @constraint(m, [i = 1:2], ∂(x[i], t) == v[i])
 @constraint(m, [i = 1:2], ∂(v[i], t) == u[i])
 
 # Ensure we hit all the waypoints:
-@constraint(m, [i = 1:2, j = eachindex(tw)], x[i] == xw[i, j], DomainRestrictions(t => tw[j]))
+@constraint(m, [i = 1:2, j = eachindex(tw)], x[i](tw[j]) == xw[i, j])
 
 # ## Problem Solution
 

--- a/docs/src/examples/Optimal Control/pandemic_control.jl
+++ b/docs/src/examples/Optimal Control/pandemic_control.jl
@@ -146,10 +146,10 @@ add_supports(t, extra_ts)
 # i(t, \xi) \leq i_{max}, \ \forall t \in \mathcal{D}_t, \xi \in \mathcal{D}_{\xi}.
 # ```
 ## Define the initial conditions
-@constraint(model, s == s0, DomainRestrictions(t => 0))
-@constraint(model, e == e0, DomainRestrictions(t => 0))
-@constraint(model, i == i0, DomainRestrictions(t => 0))
-@constraint(model, r == r0, DomainRestrictions(t => 0))
+@constraint(model, s(0, ξ) == s0)
+@constraint(model, e(0, ξ) == e0)
+@constraint(model, i(0, ξ) == i0)
+@constraint(model, r(0, ξ) == r0)
 
 ## Define the SEIR equations
 @constraint(model, s_constr, ∂(s, t) == -(1 - u) * β * si)

--- a/docs/src/guide/constraint.md
+++ b/docs/src/guide/constraint.md
@@ -130,6 +130,15 @@ initial : yb(t) = 0.0, ∀ t = 0
 Thus, we have added a constraint to `model` defined over the sub-domain ``t = 0`` 
 in accordance with the initial condition.
 
+!!! tip 
+    Boundary conditions can often be more efficiently defined using 
+    [Restricted Variables](@ref). For example, the above initial condition 
+    can be expressed:
+    ```jldoctest constrs
+    julia> @constraint(model, yb(0) == 0)
+    yb(0) = 0.0
+    ```
+
 More complex sub-domains can be specified by simply adding more restrictions. To 
 illustrate this, let's define the constraint 
 ``2y_b^2(t, x) + z_1 \geq 3, \ \forall t = 0, \ x \in [-1, 1]^2``:
@@ -275,10 +284,8 @@ julia> @constraint(model, [i = 1:2], ya^2 + z[i] <= 1, DomainRestrictions(x[i] =
 ```
 
 !!! tip
-    For more complex constraint restrictions that `DomainRestrictions` won't 
-    allow (e.g., manually defining derivative approximations), consider using  
-    [Restricted Variables](@ref) instead. However, where possible it will be 
-    more performant to use `DomainRestrictions` instead.
+    Where possible, using [Restricted Variables](@ref) will tend to be more 
+    performant than using `DomainRestrictions` instead.
 
 ## Queries
 In this section, we describe a variety of methods to extract constraint
@@ -381,7 +388,7 @@ provided for the cases in which one wants to query solely off of set or off
 expression type. Let's illustrate this with `num_constraints`:
 ```jldoctest constrs
 julia> num_constraints(model) # total number of constraints
-15
+16
 
 julia> num_constraints(model, GenericQuadExpr{Float64, GeneralVariableRef})
 5

--- a/docs/src/guide/derivative.md
+++ b/docs/src/guide/derivative.md
@@ -113,10 +113,10 @@ julia> set_all_derivative_methods(model, FiniteDifference(Forward()))
     `InfiniteOpt` does not ensure proper boundary conditions are provided by the 
     user. Thus, it is imperative that the user ensure these are provided appropriately 
     with the derivative evaluation method that is used. We recommend specifying 
-    such conditions via a constraint that uses [`DomainRestrictions`](@ref). For 
+    such conditions via a constraint that uses [Restricted Variables](@ref). For 
     example:
     ```julia
-    @constraint(model, initial_condition, y == 42, DomainRestrictions(t => 0))
+    @constraint(model, initial_condition, y(0) == 42)
     ```
 
 ## Advanced Definition 
@@ -152,8 +152,7 @@ true
 ```
 Here the argument variable can be an infinite variable, semi-infinite variable, 
 derivative, or measure that depends on the infinite parameter provided. This will 
-error to the contrary or if such a derivative has already been to the model 
-associated with the infinite parameter. 
+error to the contrary.
 
 Now we can add the derivative to the model via [`add_derivative`](@ref) which 
 will add the [`Derivative`](@ref) object and return `GeneralVariableRef` pointing 
@@ -193,12 +192,11 @@ This will also support anonymous definition and multi-dimensional definition.
 Please see [Macro Variable Definition](@ref) for more information.
 
 Second, for more convenient definition we use [`@deriv`](@ref) (or [`@∂`](@ref)) 
-as shown in the  Basic Usage section above. Unlike `@variable` this can handle any 
-`InfiniteOpt` expression as the argument input and will automatically take care of 
-any redundant derivative creation by using the existing derivatives as appropriate. 
-It also can build derivatives that depend on multiple infinite parameters and/or 
-are taken to higher orders. This is accomplished via recursive derivative 
-definition, handling the nesting as appropriate. For example, we can "define" 
+as shown in the Basic Usage section above. Unlike `@variable` this can handle any 
+`InfiniteOpt` expression as the argument input. It also can build derivatives 
+that depend on multiple infinite parameters and/or are taken to higher orders. 
+This is accomplished via recursive derivative definition, handling the nesting 
+as appropriate. For example, we can "define" 
 ``\frac{\partial^2 y(t, \xi)}{\partial t^2}`` again:
 ```jldoctest deriv_basic 
 julia> @deriv(d1, t)
@@ -207,18 +205,17 @@ dydt2(t, ξ)
 julia> @deriv(y, t^2)
 dydt2(t, ξ)
 ```
-Notice that no error is thrown (which would have occurred if we called 
-`@variable` again) and that the derivative references all point to the 
-same derivative object we defined up above with its alias name `dydt2`. This macro 
-can also tackle complex expressions using the appropriate calculus such as:
+Notice that the derivative references all point to the same derivative object we 
+defined up above with its alias name `dydt2`. This macro can also tackle complex 
+expressions using the appropriate calculus such as:
 ```jldoctest deriv_basic 
 julia> @deriv(∫(y, ξ) * q, t)
 ∂/∂t[∫{ξ ∈ [-1, 1]}[y(t, ξ)]]*q(t) + ∂/∂t[q(t)]*∫{ξ ∈ [-1, 1]}[y(t, ξ)]
 ```
 Thus, demonstrating the convenience of using `@deriv`.
 
-With all this in mind, we recommend using `@deriv` as the defacto method, but then 
-using `@variable` as a convenient way to specify information constraints 
+With all this in mind, we recommend using `@deriv` as the defacto method, but 
+then using `@variable` as a convenient way to specify information constraints 
 and an initial guess value/trajectory. 
 
 ## Derivative Evaluation

--- a/docs/src/guide/optimize.md
+++ b/docs/src/guide/optimize.md
@@ -39,7 +39,7 @@ julia> @objective(model, Min, 2z);
 
 julia> @constraint(model, c1, z >= y);
 
-julia> @constraint(model, c2, y == 42, DomainRestrictions(t => 0));
+julia> @constraint(model, c2, y(0) == 42);
 
 julia> print(model)
 Min 2 z
@@ -47,7 +47,8 @@ Subject to
  y(t) ≥ 0.0, ∀ t ∈ [0, 10]
  z ≥ 0.0
  c1 : z - y(t) ≥ 0.0, ∀ t ∈ [0, 10]
- c2 : y(t) = 42.0, ∀ t = 0
+ y(0) ≥ 0.0
+ c2 : y(0) = 42.0
 ```
 Now we optimize the model using `optimize!`:
 ```jldoctest optimize

--- a/docs/src/guide/optimize.md
+++ b/docs/src/guide/optimize.md
@@ -45,7 +45,7 @@ julia> print(model)
 Min 2 z
 Subject to
  y(t) ≥ 0.0, ∀ t ∈ [0, 10]
- z ≥ 0
+ z ≥ 0.0
  c1 : z - y(t) ≥ 0.0, ∀ t ∈ [0, 10]
  c2 : y(t) = 42.0, ∀ t = 0
 ```

--- a/docs/src/guide/result.md
+++ b/docs/src/guide/result.md
@@ -33,15 +33,16 @@ julia> @objective(model, Min, 2z);
 
 julia> @constraint(model, c1, z >= y);
 
-julia> @constraint(model, c2, y == 42, DomainRestrictions(t => 0));
+julia> @constraint(model, c2, y(0) == 42);
 
 julia> print(model)
 Min 2 z
 Subject to
  y(t) ≥ 0.0, ∀ t ∈ [0, 10]
- z ≥ 0
+ z ≥ 0.0
  c1 : z - y(t) ≥ 0.0, ∀ t ∈ [0, 10]
- c2 : y(t) = 42.0, ∀ t = 0
+ y(0) ≥ 0.0
+ c2 : y(0) = 42.0
 
 julia> optimize!(model)
 

--- a/docs/src/guide/transcribe.md
+++ b/docs/src/guide/transcribe.md
@@ -49,8 +49,8 @@ z
 julia> @objective(inf_model, Min, 2z + support_sum(y, t))
 2 z + support_sum{t}[y(t)]
 
-julia> @constraint(inf_model, initial, y == 1, DomainRestrictions(t => 0))
-initial : y(t) = 1.0, ∀ t = 0
+julia> @constraint(inf_model, initial, y(0) == 1)
+initial : y(0) = 1.0
 
 julia> @constraint(inf_model, constr, y^2 - z <= 42)
 constr : y(t)² - z ≤ 42.0, ∀ t ∈ [0, 10]
@@ -60,7 +60,8 @@ Min 2 z + support_sum{t}[y(t)]
 Subject to
  y(t) ≥ 0.0, ∀ t ∈ [0, 10]
  z binary
- initial : y(t) = 1.0, ∀ t = 0
+ y(0) ≥ 0.0
+ initial : y(0) = 1.0
  constr : y(t)² - z ≤ 42.0, ∀ t ∈ [0, 10]
 ```
 Now we can make `JuMP` model containing the transcribed version of `inf_model` 
@@ -286,8 +287,8 @@ inf_model = InfiniteModel()
 @objective(inf_model, Min, support_sum(y^2, t))
 
 # Define the constraints
-@constraint(inf_model, y == 1, DomainRestrictions(t => 0))
-@constraint(inf_model, g == 0, DomainRestrictions(t => 0))
+@constraint(inf_model, y(0) == 1)
+@constraint(inf_model, g(0, x) == 0)
 @constraint(inf_model, support_sum(deriv(g, t), x) == 42) # support_sum for simplicity
 @constraint(inf_model, 3g + y^2 <= 2)
 
@@ -297,8 +298,8 @@ print(inf_model)
 # output
 Min support_sum{t}[y(t)²]
 Subject to
- y(t) = 1.0, ∀ t = 0
- g(t, x) = 0.0, ∀ t = 0, x[1] ∈ [-1, 1], x[2] ∈ [-1, 1]
+ y(0) = 1.0
+ g(0, [x[1], x[2]]) = 0.0, ∀ x[1] ∈ [-1, 1], x[2] ∈ [-1, 1]
  support_sum{x}[∂/∂t[g(t, x)]] = 42.0, ∀ t ∈ [0, 10]
  y(t)² + 3 g(t, x) ≤ 2.0, ∀ t ∈ [0, 10], x[1] ∈ [-1, 1], x[2] ∈ [-1, 1]
 ```

--- a/docs/src/guide/variable.md
+++ b/docs/src/guide/variable.md
@@ -98,16 +98,18 @@ julia> @variable(model, w0[i = 1:3], SemiInfinite(w[i], 0, x))
  w0[3]
 ```
 Thus we create a Julia array variable `w0` whose elements `w0[i]` point to their
-respective semi-infinite variables `w[i](0, x)` stored in `model`.
-
-!!! note
-    Semi-infinite variables are provided for enhancing the generality of
-    `InfiniteOpt`, but typically can be avoided by using infinite variables in
-    combination with adding [`DomainRestrictions`](@ref) to constraints which 
-    restrict the infinite domain as needed.
-
-See [Restricted Variables](@ref) to learn about symbolic inline definition of 
-semi-infinite variables.
+respective semi-infinite variables `w[i](0, x)` stored in `model`. Alternatively, 
+we can make a semi-infinite variable via our restriction syntax:
+```jldoctest var_basic
+julia> [w[i](0, x) for i in 1:3]
+3-element Vector{GeneralVariableRef}:
+ w0[1]
+ w0[2]
+ w0[3]
+```
+These are often useful to define semi-infinite variables directly in constraint 
+expressions. See [Restricted Variables](@ref) to learn about symbolic inline 
+definition of semi-infinite variables.
 
 ### Point Variables
 Now let's add some point variables. These allow us to consider an infinite
@@ -126,14 +128,14 @@ these are overwritten with properties specified for the point variable. In this
 case the lower bound inherited from `y(t)` is overwritten by instead fixing
 `y(0)` to a value of 0.  
 
-!!! note
-    Point variables are provided for enhancing the generality of
-    `InfiniteOpt`, but typically can be avoided by using infinite variables in
-    combination with adding [`DomainRestrictions`](@ref) to constraints which 
-    restrict the infinite domain as needed.
-
-See [Restricted Variables](@ref) to learn about symbolic inline definition of 
-point variables.
+Alternatively, we can use the convenient restriction syntax:
+```jldoctest var_basic
+julia> y(0)
+y0
+```
+Again this is very useful when embedded directly in constraint expressions 
+(e.g., when defining boundary conditions). See [Restricted Variables](@ref) to 
+learn about symbolic inline definition of point variables.
 
 ### Finite Variables
 Finally, we can add finite variables to our model. These denote variables that
@@ -612,8 +614,7 @@ julia> @variables(model, begin
 
 ## Restricted Variables
 To define point and semi-infinite variables, we can also use [`restrict`](@ref) 
-for convenient inline definitions. This can be convenient for certain complex 
-constraint definition schemes, but should be used cautiously. 
+for convenient inline definitions.
 
 For example, let's consider restricting the infinite variable `y(t, x)`:
 ```jldoctest restrict_vars; setup = :(using InfiniteOpt)
@@ -642,13 +643,6 @@ y(0, [-1, 1])
 julia> semi = y(0, x) # make semi-infinite variable y(0, x)
 y(0, [x[1], x[2]])
 ```
-These can be conviently embedded in constraints to enable more complex schemes 
-than what using [`DomainRestrictions`](@ref) can acheive. 
-
-!!! note 
-    Where possible [`DomainRestrictions`](@ref) should be used instead of 
-    defining restricted variables when creating constraints for better 
-    performance.
 
 ## Queries
 `InfiniteOpt` contains a large suite of methods to query information about

--- a/docs/src/manual/measure.md
+++ b/docs/src/manual/measure.md
@@ -119,8 +119,7 @@ InfiniteOpt.analytic_expansion
 InfiniteOpt.expand_measures
 make_point_variable_ref
 make_semi_infinite_variable_ref
-add_measure_variable(::JuMP.Model, ::Any, ::Any)
-delete_internal_semi_infinite_variable
-delete_semi_infinite_variable(::JuMP.Model, ::Any, ::Any)
+add_point_variable(::JuMP.Model, ::Any, ::Any, ::Any)
+add_semi_infinite_variable(::JuMP.Model, ::Any, ::Any)
 internal_semi_infinite_variable
 ```

--- a/docs/src/manual/transcribe.md
+++ b/docs/src/manual/transcribe.md
@@ -18,9 +18,8 @@ InfiniteOpt.TranscriptionOpt.transcribe_objective!
 InfiniteOpt.TranscriptionOpt.transcribe_constraints!
 InfiniteOpt.TranscriptionOpt.transcribe_derivative_evaluations!
 InfiniteOpt.TranscriptionOpt.build_transcription_model!
-InfiniteOpt.add_measure_variable(::JuMP.Model,::InfiniteOpt.PointVariable,::Val{:TransData})
-InfiniteOpt.add_measure_variable(::JuMP.Model,::InfiniteOpt.SemiInfiniteVariable,::Val{:TransData})
-InfiniteOpt.delete_semi_infinite_variable(::JuMP.Model,::InfiniteOpt.SemiInfiniteVariableRef,::Val{:TransData})
+InfiniteOpt.add_point_variable(::JuMP.Model,::InfiniteOpt.GeneralVariableRef,::Vector{Float64},::Val{:TransData})
+InfiniteOpt.add_semi_infinite_variable(::JuMP.Model,::InfiniteOpt.SemiInfiniteVariable,::Val{:TransData})
 InfiniteOpt.build_optimizer_model!(::InfiniteOpt.InfiniteModel,::Val{:TransData})
 ```
 

--- a/docs/src/manual/variable.md
+++ b/docs/src/manual/variable.md
@@ -13,8 +13,8 @@ which originates from `JuMP.jl`.
 InfOptVariableType
 Infinite
 JuMP.build_variable(::Function, ::JuMP.VariableInfo, ::Infinite)
+JuMP.add_variable(::InfiniteModel, ::InfiniteVariable, ::String)
 InfiniteVariable
-JuMP.add_variable(::InfiniteModel, ::JuMP.AbstractVariable, ::String)
 restrict
 VariableData
 InfiniteVariableIndex
@@ -27,6 +27,7 @@ InfiniteOpt.Collections.VectorTuple
 SemiInfinite
 JuMP.build_variable(::Function, ::JuMP.VariableInfo, ::SemiInfinite)
 JuMP.build_variable(::Function, ::GeneralVariableRef, ::Dict{Int, Float64})
+JuMP.add_variable(::InfiniteModel, ::SemiInfiniteVariable, ::String)
 SemiInfiniteVariable
 SemiInfiniteVariableIndex
 SemiInfiniteVariableRef
@@ -36,6 +37,7 @@ SemiInfiniteVariableRef
 ```@docs
 Point
 JuMP.build_variable(::Function, ::JuMP.VariableInfo, ::Point)
+JuMP.add_variable(::InfiniteModel, ::PointVariable, ::String)
 PointVariable
 PointVariableIndex
 PointVariableRef
@@ -47,6 +49,7 @@ Note that finite variables simply correspond to using
 which originates from `JuMP.jl` as well. In other words, these are defined via 
 `JuMP.@variable` without specifying any [`InfOptVariableType`](@ref).
 ```@docs
+JuMP.add_variable(::InfiniteModel, ::JuMP.ScalarVariable, ::String)
 FiniteVariableIndex
 FiniteVariableRef
 ```

--- a/docs/src/tutorials/quick_start.md
+++ b/docs/src/tutorials/quick_start.md
@@ -172,22 +172,22 @@ objectives must evaluate over all included infinite domains.
 
 Now let's define the initial conditions using 
 [`@constraint`](https://jump.dev/JuMP.jl/v0.21.8/reference/constraints/#JuMP.@constraint) 
-in combination with [`DomainRestrictions`](@ref) which will restrict the domain 
-of the constraints to only be enforced at the initial time:
+in combination with [Restricted Variables](@ref) which will restrict the domain 
+of the variables to only be enforced at the initial time:
  ```jldoctest quick
-julia> @constraint(model, [i in I], x[i] == x0[i], DomainRestrictions(t => 0))
+julia> @constraint(model, [i in I], x[i](0, ξ) == x0[i])
 1-dimensional DenseAxisArray{InfOptConstraintRef,1,...} with index sets:
     Dimension 1, 1:2
 And data, a 2-element Vector{InfOptConstraintRef}:
- x[1](t, ξ) = 0.0, ∀ t = 0, ξ ~ Normal
- x[2](t, ξ) = 0.0, ∀ t = 0, ξ ~ Normal
+ x[1](0, ξ) = 0.0, ∀ ξ ~ Normal
+ x[2](0, ξ) = 0.0, ∀ ξ ~ Normal
 
-julia> @constraint(model, [i in I], v[i] == v0[i], DomainRestrictions(t => 0))
+julia> @constraint(model, [i in I], v[i](0, ξ) == v0[i])
 1-dimensional DenseAxisArray{InfOptConstraintRef,1,...} with index sets:
     Dimension 1, 1:2
 And data, a 2-element Vector{InfOptConstraintRef}:
- v[1](t, ξ) = 0.0, ∀ t = 0, ξ ~ Normal
- v[2](t, ξ) = 0.0, ∀ t = 0, ξ ~ Normal
+ v[1](0, ξ) = 0.0, ∀ ξ ~ Normal
+ v[2](0, ξ) = 0.0, ∀ ξ ~ Normal
 ```
 Note it is important that we include appropriate boundary conditions when using 
 derivatives in our model. For more information please see 
@@ -214,14 +214,14 @@ And data, a 2-element Vector{InfOptConstraintRef}:
 
 Finally, we can define our last 2 constraints:
  ```jldoctest quick
-julia> @constraint(model, c3[w in W], y[w] == sum((x[i] - p[i, w])^2 for i in I), DomainRestrictions(t => tw[w]))
+julia> @constraint(model, c3[w in W], y[w] == sum((x[i](tw[w], ξ) - p[i, w])^2 for i in I))
 1-dimensional DenseAxisArray{InfOptConstraintRef,1,...} with index sets:
     Dimension 1, 1:4
 And data, a 4-element Vector{InfOptConstraintRef}:
- c3[1] : -x[1](t, ξ)² - x[2](t, ξ)² + y[1](ξ) + 2 x[1](t, ξ) + 2 x[2](t, ξ) = 2.0, ∀ t = 0, ξ ~ Normal
- c3[2] : -x[1](t, ξ)² - x[2](t, ξ)² + y[2](ξ) + 8 x[1](t, ξ) + 6 x[2](t, ξ) = 25.0, ∀ t = 25, ξ ~ Normal
- c3[3] : -x[1](t, ξ)² - x[2](t, ξ)² + y[3](ξ) + 12 x[1](t, ξ) = 36.0, ∀ t = 50, ξ ~ Normal
- c3[4] : -x[1](t, ξ)² - x[2](t, ξ)² + y[4](ξ) + 2 x[1](t, ξ) + 2 x[2](t, ξ) = 2.0, ∀ t = 60, ξ ~ Normal
+ c3[1] : -x[1](0, ξ)² - x[2](0, ξ)² + y[1](ξ) + 2 x[1](0, ξ) + 2 x[2](0, ξ) = 2.0, ∀ ξ ~ Normal
+ c3[2] : -x[1](25, ξ)² - x[2](25, ξ)² + y[2](ξ) + 8 x[1](25, ξ) + 6 x[2](25, ξ) = 25.0, ∀ ξ ~ Normal
+ c3[3] : -x[1](50, ξ)² - x[2](50, ξ)² + y[3](ξ) + 12 x[1](50, ξ) = 36.0, ∀ ξ ~ Normal
+ c3[4] : -x[1](60, ξ)² - x[2](60, ξ)² + y[4](ξ) + 2 x[1](60, ξ) + 2 x[2](60, ξ) = 2.0, ∀ ξ ~ Normal
 
 julia> @constraint(model, c4, expect(sum(y[w] for w in W), ξ) <= ϵ)
 c4 : 𝔼{ξ}[y[1](ξ) + y[2](ξ) + y[3](ξ) + y[4](ξ)] - ϵ ≤ 0.0
@@ -300,14 +300,13 @@ model = InfiniteModel(Ipopt.Optimizer)
 @objective(model, Min, integral(sum(u[i]^2 for i in I), t))
 
 # SET THE INITIAL CONDITIONS
-@constraint(model, [i in I], x[i] == x0[i], DomainRestrictions(t => 0))
-@constraint(model, [i in I](t == 0), v[i] == v0[i], DomainRestrictions(t => 0))
+@constraint(model, [i in I], x[i](0, ξ) == x0[i])
+@constraint(model, [i in I], v[i](0, ξ) == v0[i])
 
 # SET THE PROBLEM CONSTRAINTS
 @constraint(model, c1[i in I], @deriv(x[i], t) == v[i])
 @constraint(model, c2[i in I], ξ * @deriv(v[i], t) == u[i])
-@constraint(model, c3[w in W], y[w] == sum((x[i] - p[i, w])^2 for i in I), 
-            DomainRestrictions(t => tw[w]))
+@constraint(model, c3[w in W], y[w] == sum((x[i](tw[w], ξ) - p[i, w])^2 for i in I))
 @constraint(model, c4, expect(sum(y[w] for w in W), ξ) <= ϵ)
 
 # SOLVE THE MODEL

--- a/src/TranscriptionOpt/measures.jl
+++ b/src/TranscriptionOpt/measures.jl
@@ -1,74 +1,84 @@
 """
-    InfiniteOpt.add_measure_variable(model::JuMP.Model,
-                                     var::InfiniteOpt.PointVariable,
-                                     key::Val{:TransData}
-                                     )::InfiniteOpt.GeneralVariableRef
+    InfiniteOpt.add_point_variable(model::JuMP.Model,
+                                   var::InfiniteOpt.PointVariable,
+                                   key::Val{:TransData}
+                                   )::InfiniteOpt.GeneralVariableRef
 
 Make a `PointVariableRef` and map it to the appropriate transcription variable
 and return the `GeneralVariableRef`. This is an extension of
-[`add_measure_variable`](@ref InfiniteOpt.add_measure_variable(::JuMP.Model,::Any,::Any))
+[`add_point_variable`](@ref InfiniteOpt.add_point_variable(::JuMP.Model,::Any,::Any, ::Any))
 for `TranscriptionOpt`.
 """
-function InfiniteOpt.add_measure_variable(
+function InfiniteOpt.add_point_variable(
     model::JuMP.Model,
-    var::InfiniteOpt.PointVariable,
-    key::Val{:TransData}
+    ivref::InfiniteOpt.GeneralVariableRef,
+    support::Vector{Float64},
+    ::Val{:TransData}
     )::InfiniteOpt.GeneralVariableRef
-    # make negative index to not conflict with the InfiniteModel
-    raw_index = transcription_data(model).last_point_index -= 1
-    # make the reference and map it to a transcription variable
-    ivref = var.infinite_variable_ref
-    pvref = InfiniteOpt.GeneralVariableRef(JuMP.owner_model(ivref), raw_index,
-                                           InfiniteOpt.PointVariableIndex)
-    trans_var = lookup_by_support(model, ivref, var.parameter_values)
-    transcription_data(model).finvar_mappings[pvref] = trans_var
-    return pvref
+    # check if an internal variable was already created
+    data = transcription_data(model)
+    internal_vref = get(data.point_lookup, (ivref, support), nothing)
+    if internal_vref !== nothing 
+        return internal_vref
+    end
+    # check if whether the infinite model already has one, else create one
+    inf_model = JuMP.owner_model(ivref)
+    inf_model_index = get(inf_model.point_lookup, (ivref, support), nothing)
+    if inf_model_index !== nothing
+        return InfiniteOpt._make_variable_ref(inf_model, inf_model_index)
+    else
+        # make negative index to not conflict with the InfiniteModel
+        raw_index = data.last_point_index -= 1
+        # make the reference and map it to a transcription variable
+        pvref = InfiniteOpt.GeneralVariableRef(JuMP.owner_model(ivref), raw_index,
+                                               InfiniteOpt.PointVariableIndex)
+        trans_var = lookup_by_support(model, ivref, support)
+        data.finvar_mappings[pvref] = trans_var
+        data.point_lookup[(ivref, support)] = pvref
+        return pvref
+    end
 end
 
 """
-    InfiniteOpt.add_measure_variable(model::JuMP.Model,
+    InfiniteOpt.add_semi_infinite_variable(model::JuMP.Model,
                                      var::InfiniteOpt.SemiInfiniteVariable,
                                      key::Val{:TransData}
                                      )::InfiniteOpt.GeneralVariableRef
 
-Make a `SemiInfiniteVariableRef` and add `var` to the transcription data
-and return the `GeneralVariableRef`. This is an extension of
-[`add_measure_variable`](@ref InfiniteOpt.add_measure_variable(::JuMP.Model,::Any,::Any))
-for `TranscriptionOpt`. Note that `internal_semi_infinite_variable` is also extended
-to be able to access the `var`.
+Make a `SemiInfiniteVariableRef` and add `var` to the transcription data 
+and return the `GeneralVariableRef`. This is an extension of 
+[`add_semi_infinite_variable`](@ref InfiniteOpt.add_semi_infinite_variable(::JuMP.Model,::Any,::Any)) 
+for `TranscriptionOpt`. Note that `internal_semi_infinite_variable` is also 
+extended to be able to access the `var`.
 """
-function InfiniteOpt.add_measure_variable(
+function InfiniteOpt.add_semi_infinite_variable(
     model::JuMP.Model,
     var::InfiniteOpt.SemiInfiniteVariable,
-    key::Val{:TransData}
+    ::Val{:TransData}
     )::InfiniteOpt.GeneralVariableRef
-    # make negative index to not conflict with the InfiniteModel
-    semi_infinite_vars = transcription_data(model).semi_infinite_vars
-    raw_index = -1 * (length(semi_infinite_vars) + 1)
-    # make the reference and map it to a transcription variable
+    # check if an internal variable was already created
     ivref = var.infinite_variable_ref
-    rvref = InfiniteOpt.GeneralVariableRef(JuMP.owner_model(ivref), raw_index,
-                                           InfiniteOpt.SemiInfiniteVariableIndex)
-    push!(semi_infinite_vars, var)
-    _set_semi_infinite_variable_mapping(model, var, rvref, InfiniteOpt._index_type(ivref))
-    return rvref
-end
-
-"""
-    InfiniteOpt.delete_semi_infinite_variable(model::JuMP.Model,
-                                        vref::InfiniteOpt.SemiInfiniteVariableRef,
-                                        key::Val{:TransData})::Nothing
-
-This is an extension of
-[`delete_semi_infinite_variable`](@ref InfiniteOpt.delete_semi_infinite_variable(::JuMP.Model, ::Any, ::Any))
-for use in `TranscriptionOpt`. Here we do not delete semi-infinite variables once they
-have been used since there is no performance gain for this paradigm and the
-memory saving is small. Note this may change in the future.
-"""
-function InfiniteOpt.delete_semi_infinite_variable(
-    model::JuMP.Model,
-    rvref::InfiniteOpt.SemiInfiniteVariableRef,
-    key::Val{:TransData}
-    )::Nothing
-    return
+    eval_supps = var.eval_supports
+    data = transcription_data(model)
+    internal_vref = get(data.semi_lookup, (ivref, eval_supps), nothing)
+    if internal_vref !== nothing 
+        return internal_vref
+    end
+    # check if whether the infinite model already has one, else create one
+    inf_model = JuMP.owner_model(ivref)
+    inf_model_index = get(inf_model.semi_lookup, (ivref, eval_supps), nothing)
+    if inf_model_index !== nothing
+        return InfiniteOpt._make_variable_ref(inf_model, inf_model_index)
+    else
+        # make negative index to not conflict with the InfiniteModel
+        semi_infinite_vars = transcription_data(model).semi_infinite_vars
+        raw_index = -1 * (length(semi_infinite_vars) + 1)
+        # make the reference and map it to a transcription variable
+        rvref = InfiniteOpt.GeneralVariableRef(JuMP.owner_model(ivref), raw_index,
+                                               InfiniteOpt.SemiInfiniteVariableIndex)
+        push!(semi_infinite_vars, var)
+        _set_semi_infinite_variable_mapping(model, var, rvref, InfiniteOpt._index_type(ivref))
+        data.semi_lookup[(ivref, eval_supps)] = rvref
+        return rvref
+    end
 end

--- a/src/TranscriptionOpt/model.jl
+++ b/src/TranscriptionOpt/model.jl
@@ -23,7 +23,11 @@ constructor.
    Map finite variables to their transcription variables.
 - `semi_infinite_vars::Vector{InfiniteOpt.SemiInfiniteVariable{InfiniteOpt.GeneralVariableRef}}`:
    Store the core semi-infinite variable objects of semi-infinite variables formed on transcription.
+- `semi_lookup::Dict{Tuple{InfiniteOpt.GeneralVariableRef, Dict{Int, Float64}}, InfiniteOpt.GeneralVariableRef}`: 
+  Lookup which semi-infinite variables have already been added.
 - `last_point_index::Int`: The last internal point variable index added.
+- `point_lookup::Dict{Tuple{InfiniteOpt.GeneralVariableRef, Vector{Float64}}, InfiniteOpt.GeneralVariableRef}`: 
+  Lookup which point variables have already been created internally.
 - `measure_lookup::Dict{InfiniteOpt.GeneralVariableRef, Dict{Vector{Float64}, Int}}`:
    A lookup table of measure transcriptions via support value.
 - `measure_mappings::Dict{InfiniteOpt.GeneralVariableRef, Vector{JuMP.AbstractJuMPScalar}}`:
@@ -52,7 +56,9 @@ mutable struct TranscriptionData
 
     # Internal variables (created via internal measure expansions)
     semi_infinite_vars::Vector{InfiniteOpt.SemiInfiniteVariable{InfiniteOpt.GeneralVariableRef}}
+    semi_lookup::Dict{Tuple{InfiniteOpt.GeneralVariableRef, Dict{Int, Float64}}, InfiniteOpt.GeneralVariableRef}
     last_point_index::Int
+    point_lookup::Dict{Tuple{InfiniteOpt.GeneralVariableRef, Vector{Float64}}, InfiniteOpt.GeneralVariableRef}
 
     # Measure information
     measure_lookup::Dict{InfiniteOpt.GeneralVariableRef, Dict{Vector{Float64}, Int}}
@@ -66,7 +72,7 @@ mutable struct TranscriptionData
     constr_supports::Dict{InfiniteOpt.InfOptConstraintRef,
                           Vector{Tuple}}
     constr_support_labels::Dict{InfiniteOpt.InfOptConstraintRef,
-                               Vector{Set{DataType}}}
+                                Vector{Set{DataType}}}
 
     # Collected Supports
     supports::Tuple
@@ -83,7 +89,9 @@ mutable struct TranscriptionData
                    Dict{InfiniteOpt.GeneralVariableRef, JuMP.VariableRef}(),
                    # internal variables
                    Vector{InfiniteOpt.SemiInfiniteVariable{InfiniteOpt.GeneralVariableRef}}(),
+                   Dict{Tuple{InfiniteOpt.GeneralVariableRef, Dict{Int, Float64}}, InfiniteOpt.GeneralVariableRef}(),
                    0,
+                   Dict{Tuple{InfiniteOpt.GeneralVariableRef, Vector{Float64}}, InfiniteOpt.GeneralVariableRef}(),
                    # measure info
                    Dict{InfiniteOpt.GeneralVariableRef, Dict{Vector{Float64}, Int}}(),
                    Dict{InfiniteOpt.GeneralVariableRef, Vector{JuMP.AbstractJuMPScalar}}(),

--- a/src/TranscriptionOpt/transcribe.jl
+++ b/src/TranscriptionOpt/transcribe.jl
@@ -320,7 +320,7 @@ function transcribe_semi_infinite_variables!(
         # setup the mappings
         ivref = InfiniteOpt.infinite_variable_ref(rvref)
         _set_semi_infinite_variable_mapping(trans_model, var, rvref, 
-                                      InfiniteOpt._index_type(ivref))
+                                            InfiniteOpt._index_type(ivref))
     end
     return
 end
@@ -383,7 +383,6 @@ function transcribe_point_variables!(
         # get the basic variable information
         var = object.variable
         ivref = var.infinite_variable_ref
-        param_nums = InfiniteOpt._parameter_numbers(ivref)
         supp = var.parameter_values
         # find the corresponding variable record the mapping
         vref = lookup_by_support(trans_model, ivref, supp)

--- a/src/datatypes.jl
+++ b/src/datatypes.jl
@@ -1214,8 +1214,10 @@ model an optmization problem with an infinite-dimensional decision space.
    The infinite variables and their mapping information.
 - `semi_infinite_vars::MOIUC.CleverDict{SemiInfiniteVariableIndex, <:VariableData{<:SemiInfiniteVariable}}`:
    The semi-infinite variables and their mapping information.
+- `semi_lookup::Dict{<:Tuple, SemiInfiniteVariableIndex}`: Look-up if a variable already already exists.
 - `point_vars::MOIUC.CleverDict{PointVariableIndex, <:VariableData{<:PointVariable}}`:
    The point variables and their mapping information.
+- `point_lookup::Dict{<:Tuple, PointVariableIndex}`: Look-up if a variable already exists.
 - `finite_vars::MOIUC.CleverDict{FiniteVariableIndex, VariableData{JuMP.ScalarVariable{Float64, Float64, Float64, Float64}}}`:
    The finite variables and their mapping information.
 - `name_to_var::Union{Dict{String, AbstractInfOptIndex}, Nothing}`:
@@ -1256,7 +1258,9 @@ mutable struct InfiniteModel <: JuMP.AbstractModel
     # Variable Data
     infinite_vars::MOIUC.CleverDict{InfiniteVariableIndex, <:VariableData{<:InfiniteVariable}}
     semi_infinite_vars::MOIUC.CleverDict{SemiInfiniteVariableIndex, <:VariableData{<:SemiInfiniteVariable}}
+    semi_lookup::Dict{<:Tuple, SemiInfiniteVariableIndex}
     point_vars::MOIUC.CleverDict{PointVariableIndex, <:VariableData{<:PointVariable}}
+    point_lookup::Dict{<:Tuple, PointVariableIndex}
     finite_vars::MOIUC.CleverDict{FiniteVariableIndex, VariableData{JuMP.ScalarVariable{Float64, Float64, Float64, Float64}}}
     name_to_var::Union{Dict{String, AbstractInfOptIndex}, Nothing}
 
@@ -1347,7 +1351,9 @@ function InfiniteModel(;
                          # Variables
                          MOIUC.CleverDict{InfiniteVariableIndex, VariableData{<:InfiniteVariable}}(),
                          MOIUC.CleverDict{SemiInfiniteVariableIndex, VariableData{SemiInfiniteVariable{GeneralVariableRef}}}(),
+                         Dict{Tuple{GeneralVariableRef, Dict{Int, Float64}}, SemiInfiniteVariableIndex}(),
                          MOIUC.CleverDict{PointVariableIndex, VariableData{PointVariable{GeneralVariableRef}}}(),
+                         Dict{Tuple{GeneralVariableRef, Vector{Float64}}, PointVariableIndex}(),
                          MOIUC.CleverDict{FiniteVariableIndex, VariableData{JuMP.ScalarVariable{Float64, Float64, Float64, Float64}}}(),
                          nothing,
                          # Derivatives
@@ -1433,7 +1439,9 @@ function Base.empty!(model::InfiniteModel)::InfiniteModel
     # variables
     empty!(model.infinite_vars)
     empty!(model.semi_infinite_vars)
+    empty!(model.semi_lookup)
     empty!(model.point_vars)
+    empty!(model.point_lookup)
     empty!(model.finite_vars)
     model.name_to_var = nothing
     # derivatives and measures

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -32,6 +32,19 @@ _keys(a::AbstractArray) = keys(a)
     return true
 end
 
+# Extend comparison for JuMP.VariableInfo 
+function Base.:(==)(info1::JuMP.VariableInfo, info2::JuMP.VariableInfo)::Bool 
+    return info1.has_lb == info2.has_lb && 
+           (!info1.has_lb || info1.lower_bound == info2.lower_bound) && 
+           info1.has_ub == info2.has_ub && 
+           (!info1.has_ub || info1.upper_bound == info2.upper_bound) && 
+           info1.has_fix == info2.has_fix && 
+           (!info1.has_fix || info1.fixed_value == info2.fixed_value) && 
+           info1.has_start == info2.has_start && 
+           (!info1.has_start || info1.start == info2.start) && 
+           info1.binary == info2.binary && info1.integer == info2.integer
+end
+
 ## Convert JuMP variable info to only use Float64
 # Change needed
 function _make_float_info(info::JuMP.VariableInfo

--- a/test/TranscriptionOpt/model.jl
+++ b/test/TranscriptionOpt/model.jl
@@ -469,10 +469,12 @@ end
     # test transcription expression for semi_infinite variables with 3 args
     @testset "transcription_expression (Semi-Infinite Variable)" begin
         # semi_infinite of parameter function 
-        rv = add_variable(m, build_variable(error, f, Dict(1=>1.)))
+        rv = add_variable(m, build_variable(error, f, Dict(1=>1.)), 
+                          add_support = false)
         @test IOTO.transcription_expression(tm, rv, [0., 1., 0.]) == 1
         # semi_infinite of infinite variable
-        rv = add_variable(m, build_variable(error, x, Dict(1=>1.)))
+        rv = add_variable(m, build_variable(error, x, Dict(1=>1.)), 
+                          add_support = false)
         data.infvar_mappings[rv] = [b, c]
         lookups = Dict{Vector{Float64}, Int}([0, 0] => 1, [1, 0] => 2)
         data.infvar_lookup[rv] = lookups

--- a/test/deletion.jl
+++ b/test/deletion.jl
@@ -427,6 +427,7 @@ end
     @variable(m, x)
     var = build_variable(error, inf, Dict{Int, Float64}(2 => 0.5), check = false)
     rv = add_variable(m, var)
+    var = build_variable(error, inf, Dict{Int, Float64}(2 => 0), check = false)
     rv2 = add_variable(m, var)
     data = TestData(par, 0, 1)
     meas = measure(inf + par - x + rv, data)
@@ -454,6 +455,7 @@ end
     @test InfiniteOpt._object_numbers(con2) == []
     @test InfiniteOpt._semi_infinite_variable_dependencies(inf) == []
     @test !haskey(InfiniteOpt._data_dictionary(m, SemiInfiniteVariable), JuMP.index(rv2))
+    @test isempty(m.semi_lookup)
     # test error
     @test_throws AssertionError delete(m, rv)
     @test_throws AssertionError delete(m, rv2)
@@ -531,6 +533,7 @@ end
     @test jump_function(constraint_object(con2)) == zero(JuMP.GenericAffExpr{Float64, GeneralVariableRef})
     @test objective_function(m) == zero(JuMP.GenericAffExpr{Float64, GeneralVariableRef})
     @test !haskey(InfiniteOpt._data_dictionary(m, PointVariable), JuMP.index(y))
+    @test isempty(m.point_lookup)
     # test errors
     @test_throws AssertionError delete(m, x)
     @test_throws AssertionError delete(m, y)

--- a/test/derivative_evaluation.jl
+++ b/test/derivative_evaluation.jl
@@ -136,11 +136,11 @@ end
             end
             return exs
         end
-        @test rm_zeros(nfiniteOpt.evaluate_derivative(d2, method, m)) == exprs
+        @test rm_zeros(evaluate_derivative(d2, method, m)) == exprs
         @test supports(t) == [0, 5, 10]
         @test supports(t, label = All) == [0, 2.5, 5, 7.5, 10]
         # test resolve 
-        @test rm_zeros(nfiniteOpt.evaluate_derivative(d2, method, m)) == exprs
+        @test rm_zeros(evaluate_derivative(d2, method, m)) == exprs
         @test supports(t) == [0, 5, 10]
         @test supports(t, label = All) == [0, 2.5, 5, 7.5, 10]
         @test has_generative_supports(t)

--- a/test/derivative_evaluation.jl
+++ b/test/derivative_evaluation.jl
@@ -130,11 +130,17 @@ end
                  @expression(m, M[1, 1] * d2(7.5, x) + M[1, 2] * d2(10, x) - q(7.5, x) + q(5, x)),
                  @expression(m, M[2, 1] * d2(7.5, x) + M[2, 2] * d2(7.5, x) - q(10, x) + q(5, x))]
         delete_supports(t, label = UserDefined)
-        @test InfiniteOpt.evaluate_derivative(d2, method, m) == exprs
+        function rm_zeros(exs)
+            for e in exs 
+                filter!((v, c) -> abs(c) > 1e-15, e)
+            end
+            return exs
+        end
+        @test rm_zeros(nfiniteOpt.evaluate_derivative(d2, method, m)) == exprs
         @test supports(t) == [0, 5, 10]
         @test supports(t, label = All) == [0, 2.5, 5, 7.5, 10]
         # test resolve 
-        @test InfiniteOpt.evaluate_derivative(d2, method, m) == exprs
+        @test rm_zeros(nfiniteOpt.evaluate_derivative(d2, method, m)) == exprs
         @test supports(t) == [0, 5, 10]
         @test supports(t, label = All) == [0, 2.5, 5, 7.5, 10]
         @test has_generative_supports(t)

--- a/test/derivative_evaluation.jl
+++ b/test/derivative_evaluation.jl
@@ -132,7 +132,11 @@ end
         delete_supports(t, label = UserDefined)
         function rm_zeros(exs)
             for e in exs 
-                filter!((v, c) -> abs(c) > 1e-15, e)
+                for (v, c) in e.terms
+                    if abs(c) < 1e-15
+                        delete!(e.terms, v)
+                    end
+                end
             end
             return exs
         end

--- a/test/derivative_evaluation.jl
+++ b/test/derivative_evaluation.jl
@@ -32,40 +32,21 @@
     @testset "make_reduced_expr" begin 
         # test MeasureIndex based 
         meas = support_sum(T, x)
-        pidx = length(InfiniteOpt._data_dictionary(m, PointVariable)) + 1
-        pts = [GeneralVariableRef(m, pidx, PointVariableIndex),
-               GeneralVariableRef(m, pidx + 1, PointVariableIndex)]
-        @test InfiniteOpt.make_reduced_expr(meas, t, 0.0, m) in [pts[1] + pts[2], pts[2] + pts[1]] # order is unknown
-        @test parameter_values(pts[1]) in [(0., [0., 0.]), (0., [5., 5.])]
-        @test parameter_values(pts[2]) in [(0., [0., 0.]), (0., [5., 5.])]
+        expected = [T(0, [0, 0]) + T(0, [5, 5]), T(0, [5, 5]) + T(0, [0, 0])]
+        @test InfiniteOpt.make_reduced_expr(meas, t, 0.0, m) in expected # order is unknown
         # test InfiniteVariableIndex 
-        pt = GeneralVariableRef(m, pidx + 2, PointVariableIndex)
-        @test InfiniteOpt.make_reduced_expr(q, t, 0.0, m) == pt 
-        @test parameter_values(pt) == (0.0,)
-        ridx = 3 # 2 were previously made and deleted by the measure call
-        rv = GeneralVariableRef(m, ridx, SemiInfiniteVariableIndex)
-        @test InfiniteOpt.make_reduced_expr(T, t, 0.0, m) == rv
-        @test parameter_list(rv) == [x[1], x[2]]
-        @test eval_supports(rv)[1] == 0
+        @test InfiniteOpt.make_reduced_expr(q, t, 0.0, m) == q(0)
+        @test InfiniteOpt.make_reduced_expr(T, t, 0.0, m) == T(0, x)
         # test DerivativeIndex 
-        dT = @deriv(T, x[1])
-        dq = @deriv(q, t)
-        pt = GeneralVariableRef(m, pidx + 3, PointVariableIndex)
-        @test InfiniteOpt.make_reduced_expr(dq, t, 0.0, m) == pt 
-        @test parameter_values(pt) == (0.0,)
-        rv = GeneralVariableRef(m, ridx + 1, SemiInfiniteVariableIndex)
-        @test InfiniteOpt.make_reduced_expr(dT, x[2], 0.0, m) == rv
-        @test parameter_list(rv) == [t, x[1]]
-        @test eval_supports(rv)[3] == 0
+        dT = deriv(T, x[1])
+        dq = deriv(q, t)
+        @test InfiniteOpt.make_reduced_expr(dq, t, 0.0, m) == dq(0)
+        v = dT(t, [x[1], 0])
+        @test InfiniteOpt.make_reduced_expr(dT, x[2], 0.0, m) == v
         # test SemiInfiniteVariableIndex
-        rv2 = GeneralVariableRef(m, ridx + 2, SemiInfiniteVariableIndex)
-        @test InfiniteOpt.make_reduced_expr(rv, x[1], 0.0, m) == rv2
-        @test parameter_list(rv2) == [t]
-        @test eval_supports(rv2)[3] == 0
-        @test eval_supports(rv2)[2] == 0
-        pt = GeneralVariableRef(m, pidx + 4, PointVariableIndex)
-        @test InfiniteOpt.make_reduced_expr(rv2, t, 0.0, m) == pt 
-        @test parameter_values(pt) == (0.0, [0.0, 0.0])
+        v2 = dT(t, [0, 0])
+        @test InfiniteOpt.make_reduced_expr(v, x[1], 0.0, m) == v2
+        @test InfiniteOpt.make_reduced_expr(v2, t, 0.0, m) == dT(0, [0, 0])
     end
 end
 
@@ -78,10 +59,10 @@ end
     @variable(m, y, Infinite(t))
     @variable(m, q, Infinite(t, x))
     meas = support_sum(q, t)
-    d1 = @deriv(y, t)
-    d2 = @deriv(q, t)
-    d3 = @deriv(q, x[2])
-    d4 = @deriv(meas, x[1])
+    d1 = deriv(y, t)
+    d2 = deriv(q, t)
+    d3 = deriv(q, x[2])
+    d4 = deriv(meas, x[1])
     # test fallback 
     @testset "Fallback" begin 
         @test_throws ErrorException InfiniteOpt.evaluate_derivative(d1, TestMethod(), m)
@@ -89,38 +70,20 @@ end
     # test _make_difference_expr for Forward 
     @testset "_make_difference_expr (Forward)" begin 
         supps = supports(t, label = All)
-        pidx = length(InfiniteOpt._data_dictionary(m, PointVariable)) + 1
-        pts = [GeneralVariableRef(m, pidx, PointVariableIndex),
-               GeneralVariableRef(m, pidx + 1, PointVariableIndex),
-               GeneralVariableRef(m, pidx + 2, PointVariableIndex)]
-        @test InfiniteOpt._make_difference_expr(d1, y, t, 1, supps, m, Forward()) == 5pts[1] - pts[2] + pts[3]
-        @test parameter_values(pts[1]) == (0.,)
-        @test parameter_values(pts[2]) == (5.,)
-        @test parameter_values(pts[3]) == (0.,)
+        expected = 5d1(0) - y(5) + y(0)
+        @test InfiniteOpt._make_difference_expr(d1, y, t, 1, supps, m, Forward()) == expected
     end
     # test _make_difference_expr for Central
     @testset "_make_difference_expr (Central)" begin 
         supps = supports(t, label = All)
-        ridx = length(InfiniteOpt._data_dictionary(m, SemiInfiniteVariable)) + 1
-        rvs = [GeneralVariableRef(m, ridx, SemiInfiniteVariableIndex),
-               GeneralVariableRef(m, ridx + 1, SemiInfiniteVariableIndex),
-               GeneralVariableRef(m, ridx + 2, SemiInfiniteVariableIndex)]
-        @test InfiniteOpt._make_difference_expr(d2, q, t, 2, supps, m, Central()) == 10rvs[1] - rvs[2] + rvs[3]
-        @test eval_supports(rvs[1])[1] == 5
-        @test eval_supports(rvs[2])[1] == 10
-        @test eval_supports(rvs[3])[1] == 0
+        expected = 10d2(5, x) - q(10, x) + q(0, x)
+        @test InfiniteOpt._make_difference_expr(d2, q, t, 2, supps, m, Central()) == expected
     end
     # test _make_difference_expr for FDBackward
     @testset "_make_difference_expr (Backward)" begin 
         supps = sort(supports(x[2], label = All))
-        ridx = length(InfiniteOpt._data_dictionary(m, SemiInfiniteVariable)) + 1
-        rvs = [GeneralVariableRef(m, ridx, SemiInfiniteVariableIndex),
-               GeneralVariableRef(m, ridx + 1, SemiInfiniteVariableIndex),
-               GeneralVariableRef(m, ridx + 2, SemiInfiniteVariableIndex)]
-        @test InfiniteOpt._make_difference_expr(d3, q, x[2], 2, supps, m, Backward()) == rvs[1] - rvs[2] + rvs[3]
-        @test eval_supports(rvs[1])[3] == 1
-        @test eval_supports(rvs[2])[3] == 1
-        @test eval_supports(rvs[3])[3] == 0
+        expected = d3(t, [x[1], 1]) - q(t, [x[1], 1]) + q(t, [x[1], 0])
+        @test InfiniteOpt._make_difference_expr(d3, q, x[2], 2, supps, m, Backward()) == expected
     end
     # test _make_difference_expr fallback
     @testset "_make_difference_expr (Fallback)" begin 
@@ -130,43 +93,21 @@ end
     @testset "FiniteDifference" begin 
         # test with independent parameter 
         method = FiniteDifference(Central())
-        pidx = length(InfiniteOpt._data_dictionary(m, PointVariable)) + 1
-        pts = [GeneralVariableRef(m, pidx, PointVariableIndex),
-               GeneralVariableRef(m, pidx + 1, PointVariableIndex),
-               GeneralVariableRef(m, pidx + 2, PointVariableIndex)]
-        exprs = [10pts[1] - pts[2] + pts[3]]
+        exprs = [10d1(5) - y(10) + y(0)]
         @test InfiniteOpt.evaluate_derivative(d1, method, m) == exprs 
         # test with dependent parameter 
         method = FiniteDifference(Forward()) 
-        ridx = length(InfiniteOpt._data_dictionary(m, SemiInfiniteVariable)) + 1
-        rvs = [GeneralVariableRef(m, ridx, SemiInfiniteVariableIndex),
-               GeneralVariableRef(m, ridx + 4, SemiInfiniteVariableIndex),
-               GeneralVariableRef(m, ridx + 5, SemiInfiniteVariableIndex),
-               GeneralVariableRef(m, ridx + 6, SemiInfiniteVariableIndex),
-               GeneralVariableRef(m, ridx + 10, SemiInfiniteVariableIndex),
-               GeneralVariableRef(m, ridx + 11, SemiInfiniteVariableIndex),
-               GeneralVariableRef(m, ridx + 12, SemiInfiniteVariableIndex)]
-        exprs = [rvs[1] - rvs[2] - rvs[3] - rvs[4] + rvs[5] + rvs[6] + rvs[7]] 
+        exprs = [d4([0, x[2]]) - q(0, [1, x[2]]) - q(5, [1, x[2]]) - 
+                 q(10, [1, x[2]]) + q(0, [0, x[2]]) + q(5, [0, x[2]]) + 
+                 q(10, [0, x[2]])] 
         @test InfiniteOpt.evaluate_derivative(d4, method, m) == exprs
         # test using Backward without boundary constraint
         method = FiniteDifference(Backward(), false)
-        pidx = length(InfiniteOpt._data_dictionary(m, PointVariable)) + 1
-        pts = [GeneralVariableRef(m, pidx, PointVariableIndex),
-               GeneralVariableRef(m, pidx + 1, PointVariableIndex),
-               GeneralVariableRef(m, pidx + 2, PointVariableIndex)]
-        exprs = [5pts[1] - pts[2] + pts[3]]
+        exprs = [5d1(5) - y(5) + y(0)]
         @test InfiniteOpt.evaluate_derivative(d1, method, m) == exprs 
         # test Backward with boundary constraint 
         method = FiniteDifference(Backward(), true)
-        pidx = length(InfiniteOpt._data_dictionary(m, PointVariable)) + 1
-        pts = [GeneralVariableRef(m, pidx, PointVariableIndex),
-               GeneralVariableRef(m, pidx + 1, PointVariableIndex),
-               GeneralVariableRef(m, pidx + 2, PointVariableIndex),
-               GeneralVariableRef(m, pidx + 3, PointVariableIndex),
-               GeneralVariableRef(m, pidx + 4, PointVariableIndex),
-               GeneralVariableRef(m, pidx + 5, PointVariableIndex)]
-        exprs = [5pts[1] - pts[2] + pts[3],
-                 5pts[4] - pts[5] + pts[6]]
+        exprs = [5d1(5) - y(5) + y(0), 5d1(10) - y(10) + y(5)]
         @test InfiniteOpt.evaluate_derivative(d1, method, m) == exprs 
         # test without supports 
         delete_supports(x)
@@ -174,10 +115,8 @@ end
         # test parameter function 
         f = parameter_function(sin, t)
         df = deriv(f, t)
-        pts = [GeneralVariableRef(m, pidx + 6, PointVariableIndex),
-               GeneralVariableRef(m, pidx + 7, PointVariableIndex)]
-        @test InfiniteOpt.evaluate_derivative(df, method, m) == [5pts[1] - sin(5) + sin(0), 
-                                                                 5pts[2] - sin(10) + sin(5)]
+        exprs = [5df(5) - sin(5) + sin(0), 5df(10) - sin(10) + sin(5)]
+        @test InfiniteOpt.evaluate_derivative(df, method, m) == exprs
     end
     # test OrthogonalCollocation with evaluate_derivative
     @testset "OrthogonalCollocation" begin 
@@ -186,22 +125,15 @@ end
         set_derivative_method(t, method)
         Mt = [1. 5.; 1. 10]' \ [2.5 2.5^2; 5. 25.]'
         M = Mt'
-        ridx = length(InfiniteOpt._data_dictionary(m, SemiInfiniteVariable)) + 6
-        rvs = [GeneralVariableRef(m, ridx + i, SemiInfiniteVariableIndex) for i = 1:16]
-        exprs = [@expression(m, M[1, 1] * rvs[1] + M[1, 2] * rvs[2] - rvs[3] + rvs[4]),
-                 @expression(m, M[2, 1] * rvs[5] + M[2, 2] * rvs[6] - rvs[7] + rvs[8]),
-                 @expression(m, M[1, 1] * rvs[9] + M[1, 2] * rvs[10] - rvs[11] + rvs[12]),
-                 @expression(m, M[2, 1] * rvs[13] + M[2, 2] * rvs[14] - rvs[15] + rvs[16])]
+        exprs = [@expression(m, M[1, 1] * d2(2.5, x) + M[1, 2] * d2(5, x) - q(2.5, x) + q(0, x)),
+                 @expression(m, M[2, 1] * d2(2.5, x) + M[2, 2] * d2(2.5, x) - q(5, x) + q(0, x)),
+                 @expression(m, M[1, 1] * d2(7.5, x) + M[1, 2] * d2(10, x) - q(7.5, x) + q(5, x)),
+                 @expression(m, M[2, 1] * d2(7.5, x) + M[2, 2] * d2(7.5, x) - q(10, x) + q(5, x))]
+        delete_supports(t, label = UserDefined)
         @test InfiniteOpt.evaluate_derivative(d2, method, m) == exprs
         @test supports(t) == [0, 5, 10]
         @test supports(t, label = All) == [0, 2.5, 5, 7.5, 10]
         # test resolve 
-        ridx = length(InfiniteOpt._data_dictionary(m, SemiInfiniteVariable)) + 6
-        rvs = [GeneralVariableRef(m, ridx + i, SemiInfiniteVariableIndex) for i = 1:16]
-        exprs = [@expression(m, M[1, 1] * rvs[1] + M[1, 2] * rvs[2] - rvs[3] + rvs[4]),
-                 @expression(m, M[2, 1] * rvs[5] + M[2, 2] * rvs[6] - rvs[7] + rvs[8]),
-                 @expression(m, M[1, 1] * rvs[9] + M[1, 2] * rvs[10] - rvs[11] + rvs[12]),
-                 @expression(m, M[2, 1] * rvs[13] + M[2, 2] * rvs[14] - rvs[15] + rvs[16])]
         @test InfiniteOpt.evaluate_derivative(d2, method, m) == exprs
         @test supports(t) == [0, 5, 10]
         @test supports(t, label = All) == [0, 2.5, 5, 7.5, 10]

--- a/test/derivatives.jl
+++ b/test/derivatives.jl
@@ -189,15 +189,6 @@
         @test length(InfiniteOpt._data_dictionary(dref)) == 0
         @test !is_valid(m, dref)
     end
-    # test _derivative_defaults
-    @testset "_derivative_defaults" begin 
-        @test InfiniteOpt._derivative_defaults() isa Dict{Symbol, Any}
-    end
-    # test _set_derivative_default
-    @testset "_set_derivative_default" begin 
-        @test InfiniteOpt._set_derivative_default(:extra, true) isa Nothing 
-        @test InfiniteOpt._derivative_defaults()[:extra]
-    end
 end
 
 # Test variable definition methods
@@ -215,18 +206,16 @@ end
     info = VariableInfo(false, num, false, num, false, num, false, NaN, false, false)
     info2 = VariableInfo(true, num, true, num, true, num, true, func1, false, false)
     info3 = VariableInfo(true, num, true, num, true, num, true, 42, false, true)
+    info4 = VariableInfo(true, num, false, num, false, num, false, s -> NaN, false, false)
     # build_derivative
     @testset "build_derivative" begin 
         # test errors 
-        m.deriv_lookup[(x, prefs[2])] = DerivativeIndex(4242)
         @test_throws ErrorException build_derivative(error, info, y, fin)
         @test_throws ErrorException build_derivative(error, info, y, pref)
         @test_throws ErrorException build_derivative(error, info, pref, pref)
-        @test_throws ErrorException build_derivative(error, info, x, prefs[2])
         func = (a, b, c) -> a + sum(c)
         bad_info = VariableInfo(true, num, true, num, true, num, true, func, false, false)
         @test_throws ErrorException build_derivative(error, bad_info, x, pref)
-        delete!(m.deriv_lookup, (x, prefs[2]))
         # test for expected output
         @test build_derivative(error, info, x, pref).info isa VariableInfo
         @test build_derivative(error, info, x, pref).is_vector_start
@@ -256,7 +245,7 @@ end
         @variable(m2, z, Infinite(pref3))
         d = build_derivative(error, info, z, pref3)
         # test for error of invalid variable
-        @test_throws VariableNotOwned{InfiniteVariableRef} add_variable(m, d)
+        @test_throws VariableNotOwned{InfiniteVariableRef} add_derivative(m, d)
         # prepare normal variable
         d = build_derivative(error, info, x, pref)
         # test normal
@@ -309,6 +298,16 @@ end
         @test InfiniteOpt._data_object(cref).is_info_constraint
         @test InfiniteOpt._constraint_dependencies(dref) == [InfOptConstraintIndex(i)
                                                              for i = 1:3]
+        # test redundant build 
+        idx = DerivativeIndex(1)
+        dref = DerivativeRef(m, idx)
+        gvref = InfiniteOpt._make_variable_ref(m, idx)
+        d = Derivative(info4, true, x, pref)
+        @test add_derivative(m, d, "name2") == gvref
+        @test haskey(InfiniteOpt._data_dictionary(dref), idx)
+        @test InfiniteOpt._core_variable_object(dref) == d
+        @test name(dref) == "name2"
+        @test lower_bound(dref) == 0
     end
     # test JuMP.add_variable 
     @testset "JuMP.add_variable" begin 
@@ -547,21 +546,21 @@ end
         @test upper_bound(dref) == 10
         @test start_value_function(dref) isa Function 
         # test regular with alias
-        idx = DerivativeIndex(3)
+        idx = DerivativeIndex(1)
         dref = DerivativeRef(m, idx)
         gvref = InfiniteOpt._make_variable_ref(m, idx)
-        @test @variable(m, dx <= 0, Deriv(y, x[2])) == gvref
+        @test @variable(m, dx <= 0, Deriv(y, t)) == gvref
         @test derivative_argument(dref) == y
-        @test operator_parameter(dref) == x[2]
+        @test operator_parameter(dref) == t
         @test used_by_derivative(y)
-        @test used_by_derivative(x[2])
+        @test used_by_derivative(t)
         @test upper_bound(dref) == 0
         @test name(dref) == "dx"
     end
     # test array variable definition
     @testset "Array" begin
         # test anon array with one parameter
-        idxs = [DerivativeIndex(4), DerivativeIndex(5)]
+        idxs = [DerivativeIndex(3), DerivativeIndex(4)]
         drefs = [DerivativeRef(m, idx) for idx in idxs]
         gvrefs = [InfiniteOpt._make_variable_ref(m, idx) for idx in idxs]
         @test @variable(m, [i = 1:2], Deriv(q[i], t), lower_bound = 0) == gvrefs
@@ -569,7 +568,7 @@ end
         @test operator_parameter(drefs[2]) == t
         @test lower_bound(drefs[2]) == 0
         # test explicit array 
-        idxs = [DerivativeIndex(6), DerivativeIndex(7)]
+        idxs = [DerivativeIndex(5), DerivativeIndex(6)]
         drefs = [DerivativeRef(m, idx) for idx in idxs]
         gvrefs = [InfiniteOpt._make_variable_ref(m, idx) for idx in idxs]
         @test @variable(m, q4[i = 1:2] == 3, Deriv(q[i+1], x[i])) == gvrefs
@@ -578,7 +577,7 @@ end
         @test fix_value(drefs[2]) == 3
         @test name(drefs[1]) == "q4[1]"
         # test semi anon array
-        idxs = [DerivativeIndex(8), DerivativeIndex(9)]
+        idxs = [DerivativeIndex(7), DerivativeIndex(8)]
         drefs = [DerivativeRef(m, idx) for idx in idxs]
         gvrefs = [InfiniteOpt._make_variable_ref(m, idx) for idx in idxs]
         @test @variable(m, [i = 1:2], Deriv(q[i], x[i]), lower_bound = -5) == gvrefs
@@ -589,8 +588,8 @@ end
     end
     # test errors
     @testset "Errors" begin
-        # test redefinition catch
-        @test_macro_throws ErrorException @variable(m, dy42, Deriv(y, t))
+        # test same name error
+        @test_macro_throws ErrorException @variable(m, y, Deriv(y, t))
     end
     # test the deprecations 
     @testset "@derivative_variable" begin 

--- a/test/finite_variables.jl
+++ b/test/finite_variables.jl
@@ -133,17 +133,9 @@ end
         # test normal
         @test build_variable(error, info).info == info
     end
-    # _check_and_make_variable_ref
-    @testset "_check_and_make_variable_ref" begin
-        # test normal
-        v = build_variable(error, info)
-        idx = FiniteVariableIndex(1)
-        vref = FiniteVariableRef(m, idx)
-        @test InfiniteOpt._check_and_make_variable_ref(m, v, "") == vref
-    end
     # add_variable
     @testset "JuMP.add_variable" begin
-        idx = FiniteVariableIndex(2)
+        idx = FiniteVariableIndex(1)
         vref = FiniteVariableRef(m, idx)
         gvref = InfiniteOpt._make_variable_ref(m, idx)
         v = build_variable(error, info)
@@ -153,7 +145,7 @@ end
         # prepare variable with all the possible info additions
         v = build_variable(error, info2)
         # test info addition functions
-        idx = FiniteVariableIndex(3)
+        idx = FiniteVariableIndex(2)
         vref = FiniteVariableRef(m, idx)
         gvref = InfiniteOpt._make_variable_ref(m, idx)
         @test add_variable(m, v, "name") == gvref

--- a/test/infinite_variables.jl
+++ b/test/infinite_variables.jl
@@ -12,6 +12,7 @@
     func2 = (x...) -> 1 
     info = VariableInfo(false, num, false, num, false, num, false, func, false, false)
     new_info = VariableInfo(true, 0., true, 0., true, 0., true, func2, true, false)
+    new_info2 = VariableInfo(true, 0, true, 0, true, 0, true, func2, true, false)
     var = InfiniteVariable(info, IC.VectorTuple(a, b[1:2], c, [b[3], d]),
                            [1:7...], [1:6...], true)
     var2 = InfiniteVariable(new_info, IC.VectorTuple(a, b[1:2], c, [b[3], d]),
@@ -85,6 +86,8 @@
     end
     # _update_variable_info
     @testset "_update_variable_info" begin
+        @test isa(InfiniteOpt._update_variable_info(vref, new_info2), Nothing)
+        @test InfiniteOpt._variable_info(vref) == new_info2
         @test isa(InfiniteOpt._update_variable_info(vref, new_info), Nothing)
         @test InfiniteOpt._variable_info(vref) == new_info
     end
@@ -316,22 +319,6 @@ end
         empty!(InfiniteOpt._infinite_variable_dependencies(pref))
         empty!(InfiniteOpt._infinite_variable_dependencies(prefs[1]))
         empty!(InfiniteOpt._infinite_variable_dependencies(prefs[2]))
-    end
-    # _check_and_make_variable_ref
-    @testset "_check_and_make_variable_ref" begin
-        # prepare secondary model and parameter and variable
-        m2 = InfiniteModel()
-        @infinite_parameter(m2, pref3 in [0, 1])
-        v = build_variable(error, info, Infinite(pref3))
-        # test for error of invalid variable
-        @test_throws VariableNotOwned{GeneralVariableRef} InfiniteOpt._check_and_make_variable_ref(m, v, "")
-        # test normal
-        idx = InfiniteVariableIndex(1)
-        vref = InfiniteVariableRef(m2, idx)
-        @test InfiniteOpt._check_and_make_variable_ref(m2, v, "") == vref
-        @test InfiniteOpt._infinite_variable_dependencies(pref3) == [idx]
-        # test with other variable object
-        @test_throws ArgumentError InfiniteOpt._check_and_make_variable_ref(m, :bad, "")
     end
     # add_variable
     @testset "JuMP.add_variable" begin

--- a/test/point_variables.jl
+++ b/test/point_variables.jl
@@ -166,6 +166,9 @@ end
     info = VariableInfo(false, num, false, num, false, num, false, num, false, false)
     info2 = VariableInfo(true, num, true, num, true, num, true, num, true, false)
     info3 = VariableInfo(true, num, true, num, true, num, true, num, false, true)
+    info4 = VariableInfo(true, num, true, num, true, num, true, num, true, true)
+    num = Float64(1)
+    info5 = VariableInfo(true, num, true, num, true, num, true, num, true, true)
     @variable(m, ivref, Infinite(pref, pref2))
     @variable(m, ivref2, Infinite(pref, prefs))
     divref = dispatch_variable_ref(ivref)
@@ -345,23 +348,6 @@ end
         # undo changes
         empty!(InfiniteOpt._point_variable_dependencies(ivref))
     end
-    # _check_and_make_variable_ref
-    @testset "_check_and_make_variable_ref" begin
-        # prepare secondary model and infinite variable
-        m2 = InfiniteModel()
-        @infinite_parameter(m2, pref3 in [0, 1])
-        @variable(m2, ivref3, Infinite(pref3))
-        v = build_variable(error, info, Point(ivref3, 0.5))
-        # test for invalid variable error
-        @test_throws VariableNotOwned{InfiniteVariableRef} InfiniteOpt._check_and_make_variable_ref(m, v, "")
-        # test normal
-        v = build_variable(error, info, Point(ivref3, 0))
-        idx = PointVariableIndex(1)
-        vref = PointVariableRef(m2, idx)
-        @test InfiniteOpt._check_and_make_variable_ref(m2, v, "") == vref
-        @test supports(pref3) == [0]
-        @test InfiniteOpt._point_variable_dependencies(ivref3) == [idx]
-    end
     # add_variable
     @testset "JuMP.add_variable" begin
         # prepare secondary model and infinite variable
@@ -383,7 +369,7 @@ end
         @test name(vref) == "name"
         @test InfiniteOpt._point_variable_dependencies(ivref) == [idx]
         # prepare infinite variable with all the possible info additions
-        v = build_variable(error, info2, Point(ivref, 0, 1))
+        v = build_variable(error, info2, Point(ivref, 0, 0))
         # test info addition functions
         idx = PointVariableIndex(2)
         vref = PointVariableRef(m, idx)
@@ -427,7 +413,7 @@ end
         @test InfiniteOpt._constraint_dependencies(vref) == [InfOptConstraintIndex(i)
                                                              for i = 1:4]
         # prepare infinite variable with integer info addition
-        v = build_variable(error, info3, Point(ivref, 0, 1))
+        v = build_variable(error, info3, Point(ivref, 1, 1))
         # test integer addition functions
         idx = PointVariableIndex(3)
         vref = PointVariableRef(m, idx)
@@ -444,6 +430,85 @@ end
         @test InfiniteOpt._data_object(cref).is_info_constraint
         @test InfiniteOpt._constraint_dependencies(vref) == [InfOptConstraintIndex(i)
                                                              for i = 5:8]
+        # test redundant add with same info 
+        v = build_variable(error, info, Point(ivref, 0, 1))
+        idx = PointVariableIndex(1)
+        vref = PointVariableRef(m, idx)
+        gvref = InfiniteOpt._make_variable_ref(m, idx)
+        @test add_variable(m, v, "name2") == gvref
+        @test haskey(InfiniteOpt._data_dictionary(vref), idx)
+        @test supports(pref) == [0, 1]
+        @test supports(pref2) == [0, 1]
+        @test name(vref) == "name2"
+        @test !has_upper_bound(vref)
+        # test redundant add with all new info 
+        v = build_variable(error, info4, Point(ivref, 0, 1))
+        idx = PointVariableIndex(1)
+        vref = PointVariableRef(m, idx)
+        gvref = InfiniteOpt._make_variable_ref(m, idx)
+        @test add_variable(m, v) == gvref
+        @test haskey(InfiniteOpt._data_dictionary(vref), idx)
+        @test supports(pref) == [0, 1]
+        @test supports(pref2) == [0, 1]
+        @test name(vref) == "name2"
+        @test lower_bound(vref) == 0
+        @test upper_bound(vref) == 0
+        @test fix_value(vref) == 0
+        @test start_value(vref) == 0
+        @test is_binary(vref)
+        @test is_integer(vref)
+        @test LowerBoundRef(vref) == InfOptConstraintRef(m, InfOptConstraintIndex(9))
+        @test UpperBoundRef(vref) == InfOptConstraintRef(m, InfOptConstraintIndex(10))
+        @test FixRef(vref) == InfOptConstraintRef(m, InfOptConstraintIndex(11))
+        @test BinaryRef(vref) == InfOptConstraintRef(m, InfOptConstraintIndex(12))
+        @test IntegerRef(vref) == InfOptConstraintRef(m, InfOptConstraintIndex(13))
+        # test redundant add with all new values info 
+        v = build_variable(error, info5, Point(ivref, 0, 1))
+        idx = PointVariableIndex(1)
+        vref = PointVariableRef(m, idx)
+        gvref = InfiniteOpt._make_variable_ref(m, idx)
+        @test add_variable(m, v, "name4") == gvref
+        @test haskey(InfiniteOpt._data_dictionary(vref), idx)
+        @test supports(pref) == [0, 1]
+        @test supports(pref2) == [0, 1]
+        @test name(vref) == "name4"
+        @test lower_bound(vref) == 1
+        @test upper_bound(vref) == 1
+        @test fix_value(vref) == 1
+        @test start_value(vref) == 1
+        @test is_binary(vref)
+        @test is_integer(vref)
+        @test LowerBoundRef(vref) == InfOptConstraintRef(m, InfOptConstraintIndex(9))
+        @test UpperBoundRef(vref) == InfOptConstraintRef(m, InfOptConstraintIndex(10))
+        @test FixRef(vref) == InfOptConstraintRef(m, InfOptConstraintIndex(11))
+        @test BinaryRef(vref) == InfOptConstraintRef(m, InfOptConstraintIndex(12))
+        @test IntegerRef(vref) == InfOptConstraintRef(m, InfOptConstraintIndex(13))
+        # test redundant add with new info that deletes 
+        v = build_variable(error, info, Point(ivref, 0, 1))
+        idx = PointVariableIndex(1)
+        vref = PointVariableRef(m, idx)
+        gvref = InfiniteOpt._make_variable_ref(m, idx)
+        @test add_variable(m, v, "name5") == gvref
+        @test haskey(InfiniteOpt._data_dictionary(vref), idx)
+        @test supports(pref) == [0, 1]
+        @test supports(pref2) == [0, 1]
+        @test name(vref) == "name5"
+        @test !has_lower_bound(vref)
+        @test !has_upper_bound(vref)
+        @test !is_fixed(vref)
+        @test start_value(vref) === nothing
+        @test !is_binary(vref)
+        @test !is_integer(vref)
+        # test add with dependent parameters 
+        v = build_variable(error, info, Point(ivref2, 0, [1, 1]))
+        idx = PointVariableIndex(4)
+        vref = PointVariableRef(m, idx)
+        gvref = InfiniteOpt._make_variable_ref(m, idx)
+        @test add_variable(m, v, "name") == gvref
+        @test haskey(InfiniteOpt._data_dictionary(vref), idx)
+        @test supports(pref) == [0, 1]
+        @test supports(prefs) == ones(2, 1)
+        @test name(vref) == "name"
     end
 end
 
@@ -471,15 +536,15 @@ end
         idx = PointVariableIndex(2)
         vref = PointVariableRef(m, idx)
         gvref = InfiniteOpt._make_variable_ref(m, idx)
-        @test @variable(m, variable_type = Point(z, 0, [0, 0]), 
+        @test @variable(m, variable_type = Point(z, 0, [1, 1]), 
                         lower_bound = -5, binary = true) == gvref
         @test infinite_variable_ref(vref) == z
-        @test parameter_values(vref) == (0, [0, 0])
+        @test parameter_values(vref) == (0, [1, 1])
         @test !is_integer(vref)
         @test is_binary(vref)
         @test lower_bound(vref) == -5
         # test regular with alias
-        idx = PointVariableIndex(3)
+        idx = PointVariableIndex(1)
         vref = PointVariableRef(m, idx)
         gvref = InfiniteOpt._make_variable_ref(m, idx)
         @test @variable(m, z0, Point(z, 0, [0, 0]), Bin) == gvref
@@ -489,7 +554,7 @@ end
         @test lower_bound(vref) == 0
         @test name(vref) == "z0"
         # test regular with semi anon
-        idx = PointVariableIndex(4)
+        idx = PointVariableIndex(1)
         vref = PointVariableRef(m, idx)
         gvref = InfiniteOpt._make_variable_ref(m, idx)
         @test @variable(m, variable_type = Point(z, 0, [0, 0]), base_name = "z0",
@@ -503,7 +568,7 @@ end
     # test array variable definition
     @testset "Array" begin
         # test anon array with one infvar
-        idxs = [PointVariableIndex(5), PointVariableIndex(6)]
+        idxs = [PointVariableIndex(1), PointVariableIndex(1)]
         vrefs = [PointVariableRef(m, idx) for idx in idxs]
         gvrefs = [InfiniteOpt._make_variable_ref(m, idx) for idx in idxs]
         @test @variable(m, [1:2], Point(z, 0, [0, 0])) == gvrefs
@@ -512,7 +577,7 @@ end
         @test is_integer(vrefs[1])
         @test lower_bound(vrefs[2]) == 0
         # test anon array with different inf vars
-        idxs = [PointVariableIndex(7), PointVariableIndex(8)]
+        idxs = [PointVariableIndex(3), PointVariableIndex(4)]
         vrefs = [PointVariableRef(m, idx) for idx in idxs]
         gvrefs = [InfiniteOpt._make_variable_ref(m, idx) for idx in idxs]
         @test @variable(m, [i = 1:2], Point(z2[i], 0)) == gvrefs
@@ -522,17 +587,17 @@ end
         @test fix_value(vrefs[2]) == 3
         @test name(vrefs[1]) == ""
         # test array with same infvar
-        idxs = [PointVariableIndex(9), PointVariableIndex(10)]
+        idxs = [PointVariableIndex(1), PointVariableIndex(5)]
         vrefs = [PointVariableRef(m, idx) for idx in idxs]
         gvrefs = [InfiniteOpt._make_variable_ref(m, idx) for idx in idxs]
-        @test @variable(m, a[1:2], Point(z, 0, [0, 0]), Bin) == gvrefs
+        @test @variable(m, a[i = 1:2], Point(z, -1 + i, [0, 0]), Bin) == gvrefs
         @test infinite_variable_ref(vrefs[1]) == z
-        @test parameter_values(vrefs[2]) == (0, [0, 0])
+        @test parameter_values(vrefs[2]) == (1, [0, 0])
         @test is_binary(vrefs[1])
         @test lower_bound(vrefs[2]) == 0
         @test name(vrefs[1]) == "a[1]"
         # test test array with differnt infvars
-        idxs = [PointVariableIndex(11), PointVariableIndex(12)]
+        idxs = [PointVariableIndex(3), PointVariableIndex(4)]
         vrefs = [PointVariableRef(m, idx) for idx in idxs]
         gvrefs = [InfiniteOpt._make_variable_ref(m, idx) for idx in idxs]
         @test @variable(m, b[i = 1:2] >= -5, Point(z2[i], 0)) == gvrefs
@@ -542,14 +607,15 @@ end
         @test lower_bound(vrefs[2]) == -5
         @test name(vrefs[1]) == "b[1]"
         # test semi anon array
-        idxs = [PointVariableIndex(13), PointVariableIndex(14)]
+        idxs = [PointVariableIndex(6), PointVariableIndex(7)]
         vrefs = [PointVariableRef(m, idx) for idx in idxs]
         gvrefs = [InfiniteOpt._make_variable_ref(m, idx) for idx in idxs]
-        @test @variable(m, [i = 1:2], Point(z2[i], 0), lower_bound = -5) == gvrefs
+        @test @variable(m, [i = 1:2], Point(z2[i], 1), lower_bound = -5) == gvrefs
         @test infinite_variable_ref(vrefs[1]) == z2[1]
         @test infinite_variable_ref(vrefs[2]) == z2[2]
         @test lower_bound(vrefs[2]) == -5
         @test name(vrefs[1]) == ""
+        @test parameter_values.(vrefs) == [(1,), (1,)]
     end
     # test errors
     @testset "Errors" begin

--- a/test/semi_infinite_variables.jl
+++ b/test/semi_infinite_variables.jl
@@ -232,36 +232,46 @@ end
         @test add_variable(m, var) == gvref
         @test name(vref) == ""
         @test eval_supports(vref) === eval_supps
+        @test supports(a) == [0.5]
+        @test supports(b[2]) == [1]
+        @test supports(c) == zeros(2, 1)
+        @test supports(b[1]) == []
         @test InfiniteOpt._object_numbers(vref) == [2]
         @test InfiniteOpt._semi_infinite_variable_dependencies(ivref) == [idx]
-        # test with set name
+        # test with set name (redundant add)
+        @test add_variable(m, var, "cat") == gvref
+        @test name(vref) == "cat"
+        # test with partial supports
+        eval_supps2 = Dict{Int, Float64}(1 => 0.5, 3 => 0, 5 => 1)
+        var = build_variable(error, ivref, eval_supps2, check = false)
         idx = SemiInfiniteVariableIndex(2)
         vref = SemiInfiniteVariableRef(m, idx)
         gvref = GeneralVariableRef(m, 2, SemiInfiniteVariableIndex)
-        @test add_variable(m, var, "cat") == gvref
-        @test name(vref) == "cat"
-        # test with no name
-        idx = SemiInfiniteVariableIndex(3)
-        vref = SemiInfiniteVariableRef(m, idx)
-        gvref = GeneralVariableRef(m, 3, SemiInfiniteVariableIndex)
         @test add_variable(m, var) == gvref
         @test InfiniteOpt._data_object(vref).name == ""
+        @test supports(a) == [0.5]
+        @test supports(b[2]) == [0, 1]
+        @test supports(b[1]) == []
+        @test supports(c) == zeros(2, 1)
     end
     # test macro definition
     @testset "Macro Definition" begin 
         # anonymous definition
-        vref = GeneralVariableRef(m, 4, SemiInfiniteVariableIndex)
+        vref = GeneralVariableRef(m, 3, SemiInfiniteVariableIndex)
         @test @variable(m, variable_type = SemiInfinite(ivref, 0, [b[1], 0], c)) == vref 
         @test parameter_refs(vref) == (b[1], c)
         @test eval_supports(vref) == Dict(1 => 0.0, 3 => 0.0)
-        # explicit definition
-        vref = GeneralVariableRef(m, 5, SemiInfiniteVariableIndex)
+        @test supports(a) == [0, 0.5]
+        @test supports(b[2]) == [0, 1]
+        @test supports(b[1]) == []
+        # explicit definition (redundant)
+        vref = GeneralVariableRef(m, 3, SemiInfiniteVariableIndex)
         @test @variable(m, test, SemiInfinite(ivref, 0, [b[1], 0], c)) == vref 
         @test parameter_refs(vref) == (b[1], c)
         @test eval_supports(vref) == Dict(1 => 0.0, 3 => 0.0)
         @test name(vref) == "test"
         # array definition
-        vrefs = [GeneralVariableRef(m, i, SemiInfiniteVariableIndex) for i in 6:7]
+        vrefs = [GeneralVariableRef(m, i, SemiInfiniteVariableIndex) for i in 4:5]
         @test @variable(m, [i = 1:2], SemiInfinite(ivref, i - 1, b, c)) == vrefs
         @test parameter_refs(vrefs[1]) == (b, c)
         @test eval_supports.(vrefs) == [Dict(1 => 0.0), Dict(1 => 1.0)]
@@ -272,12 +282,12 @@ end
         @test_throws ErrorException restrict(ivref, 0, b)
         @test_throws ErrorException ivref(0, b)
         # test normal wth restrict
-        vref = GeneralVariableRef(m, 8, SemiInfiniteVariableIndex)
+        vref = GeneralVariableRef(m, 6, SemiInfiniteVariableIndex)
         @test restrict(ivref, 0.5, [b[1], 0], c) == vref 
         @test parameter_refs(vref) == (b[1], c)
         @test eval_supports(vref) == Dict(1 => 0.5, 3 => 0.0)
         # test normal functionally
-        vref = GeneralVariableRef(m, 9, SemiInfiniteVariableIndex)
+        vref = GeneralVariableRef(m, 6, SemiInfiniteVariableIndex)
         @test ivref(0.5, [b[1], 0], c) == vref 
         @test parameter_refs(vref) == (b[1], c)
         @test eval_supports(vref) == Dict(1 => 0.5, 3 => 0.0)

--- a/test/show.jl
+++ b/test/show.jl
@@ -131,9 +131,9 @@
         @test InfiniteOpt.domain_string(IJuliaMode, domain) == "Uniform{Float64}(a=0.0, b=1.0)"
         # test mulivariate domain
         domain = MultiDistributionDomain(MvNormal([1], 1))
-        str = "IsoNormal(\ndim: 1\nμ: [1.0]\nΣ: [1.0]\n)\n"
-        @test InfiniteOpt.domain_string(REPLMode, domain) == str
-        @test InfiniteOpt.domain_string(IJuliaMode, domain) == str
+        str = "IsoNormal(\ndim: 1" # just test first part
+        @test InfiniteOpt.domain_string(REPLMode, domain)[1:length(str)] == str
+        @test InfiniteOpt.domain_string(IJuliaMode, domain)[1:length(str)]  == str
     end
     # test domain_string (CollectionDomain)
     @testset "domain_string (CollectionDomain)" begin

--- a/test/utility_tests.jl
+++ b/test/utility_tests.jl
@@ -48,6 +48,17 @@ end
     @test InfiniteOpt._allequal([1 1; 1 1])
 end
 
+# Test Base.:(==) for VariableInfo
+@testset "VariableInfo Comparison" begin
+    info1 = VariableInfo(true, 1, false, NaN, false, NaN, false, NaN, false, true)
+    info2 = VariableInfo(true, 1., false, NaN, false, NaN, false, NaN, false, true)
+    info3 = VariableInfo(true, 1, false, NaN, false, NaN, false, NaN, false, true)
+    info4 = VariableInfo(true, 1, false, NaN, false, NaN, false, NaN, false, false)
+    @test info1 == info3 
+    @test info1 == info2
+    @test info1 != info4
+end
+
 # Test _make_float_info
 @testset "_make_float_info" begin
     info1 = VariableInfo(false, 0, false, 0, false, 0, false, 0, false, false)


### PR DESCRIPTION
This closes #146. It also allows us to use macro defined derivatives repeatedly without erroring unlike before.

With v0.4.0:
```julia
function test()
       m=InfiniteModel()
       @infinite_parameter(m, t in [0, 10], derivative_method = OrthogonalCollocation(4), num_supports = 100)
       @infinite_parameter(m, x[1:2] in [0, 1], num_supports = 20)
       @variable(m, y >= 0, Infinite(t))
       @variable(m, q, Infinite(t, x))
       @objective(m, Min, integral(y + integral(q^2, x), t))
       @constraint(m, deriv(y, t) == 2y + 2)
       @constraint(m, deriv(q, t) == q + y)
       @constraint(m, y * q - 2 <= 2)
       build_optimizer_model!(m)
end
@time test()
```
```julia
1.228544 seconds (6.01 M allocations: 388.745 MiB, 7.29% gc time)
```

With this branch:
```julia
@time test()
```
```julia
0.939251 seconds (4.64 M allocations: 311.325 MiB, 11.42% gc time)
```

Hence, we have a significant decrease in the amount of memory and allocations. However, there isn't really a speed up since redundant definition wasn't a rate determining step.