### PR TITLE
Remove MOI as Explicit Dependency

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,7 +8,6 @@ DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 FastGaussQuadrature = "442a2c76-b920-505d-bb47-c5924d526838"
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
-MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 
 [compat]
@@ -16,7 +15,6 @@ DataStructures = "^0.14.2, 0.15, 0.16, 0.17, 0.18"
 Distributions = "0.19, 0.20, 0.21, 0.22, 0.23, 0.24, 0.25"
 FastGaussQuadrature = "^0.3.2, 0.4"
 JuMP = "0.21.9"
-MathOptInterface = "0.9.20"
 Reexport = "0.2, 1"
 julia = "1"
 

--- a/src/InfiniteOpt.jl
+++ b/src/InfiniteOpt.jl
@@ -5,7 +5,6 @@ import Reexport
 Reexport.@reexport using JuMP
 
 # Import the necessary packages.
-import MathOptInterface
 import Distributions
 import DataStructures
 import FastGaussQuadrature

--- a/src/TranscriptionOpt/TranscriptionOpt.jl
+++ b/src/TranscriptionOpt/TranscriptionOpt.jl
@@ -2,8 +2,7 @@ module TranscriptionOpt
 
 # Import the necessary packages.
 import JuMP
-import MathOptInterface
-const MOI = MathOptInterface
+const MOI = JuMP.MOI
 const MOIU = MOI.Utilities
 using ..InfiniteOpt
 

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -1,5 +1,3 @@
-using JuMP: REPLMode, IJuliaMode
-
 macro test_expression(expr)
     esc(quote
             @test JuMP.isequal_canonical(@expression(m, $expr), $expr)


### PR DESCRIPTION
This is a test to see if we can remove MOI.

**EDIT:** 
It appears that we can since `Reexport` exports the `MOI` alias defined in `JuMP`.