### PR TITLE
Fix Bug in Syncing Optimizer Model with Changes in InfiniteModel

### DIFF
--- a/src/array_parameters.jl
+++ b/src/array_parameters.jl
@@ -1307,22 +1307,26 @@ function add_supports(
     end
     supports = round.(supports, sigdigits = significant_digits(first(prefs)))
     current_supports = _parameter_supports(first(prefs))
+    added_new_support = false
     for i in 1:size(supports, 2)
         s = @view(supports[:, i])
         if haskey(current_supports, s)
             push!(current_supports[s], label)
         else
             current_supports[s] = Set([label])
+            added_new_support = true
         end
     end
     if label <: InternalLabel
         _set_has_internal_supports(first(prefs), true)
     end
-    for pref in prefs
-        _reset_derivative_constraints(pref)
-    end
-    if any(is_used(pref) for pref in prefs)
-        set_optimizer_model_ready(JuMP.owner_model(first(prefs)), false)
+    if added_new_support
+        for pref in prefs
+            _reset_derivative_constraints(pref)
+        end
+        if any(is_used(pref) for pref in prefs)
+            set_optimizer_model_ready(JuMP.owner_model(first(prefs)), false)
+        end
     end
     return
 end

--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -111,6 +111,7 @@ function _set_core_constraint_object(
     constr::JuMP.AbstractConstraint
     )::Nothing
     _adaptive_data_update(cref, constr, _data_object(cref))
+    set_optimizer_model_ready(JuMP.owner_model(cref), false)
     return
 end
 

--- a/src/scalar_parameters.jl
+++ b/src/scalar_parameters.jl
@@ -1286,20 +1286,24 @@ function add_supports(pref::IndependentParameterRef,
     supports = round.(supports, sigdigits = significant_digits(pref))
     check && _check_supports_in_bounds(error, supports, domain)
     supports_dict = _parameter_supports(pref)
+    added_new_support = false
     for s in supports
         if haskey(supports_dict, s)
             push!(supports_dict[s], label)
         else
             supports_dict[s] = Set([label])
+            added_new_support = true
         end
     end
-    _reset_derivative_constraints(pref)
-    _reset_generative_supports(pref)
     if label <: InternalLabel
         _set_has_internal_supports(pref, true)
     end
-    if is_used(pref)
-        set_optimizer_model_ready(JuMP.owner_model(pref), false)
+    if added_new_support
+        _reset_derivative_constraints(pref)
+        _reset_generative_supports(pref)
+        if is_used(pref)
+            set_optimizer_model_ready(JuMP.owner_model(pref), false)
+        end
     end
     return
 end


### PR DESCRIPTION
This makes it such that constraint changes trigger the optimizer model to be cleared. It also makes it so add supports only resets things if the supports are new.
