### PR TITLE
Fix Occasional Doc Workflow Error

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,7 +18,9 @@ jobs:
         with:
           version: '1.6' # Build documentation on Julia 1.6
       - name: Install plotting dependencies # For enabling GR.jl (used by Plots.jl)
-        run: sudo apt-get install -y qt5-default
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y qt5-default
       - name: Install julia dependencies
         run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
       - name: Plot friendly RUNCMD # needed to enable Plots.jl correctly


### PR DESCRIPTION
This adds `apt-get update` before loading in the necessary plotting dependencies. This follows from: https://github.com/actions/virtual-environments/issues/675. 