### PR TITLE
Require at Least Julia 1.6

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,15 +17,15 @@ SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 
 [compat]
 AbstractTrees = "0.3"
-DataStructures = "^0.14.2, 0.15, 0.16, 0.17, 0.18"
-Distributions = "0.19, 0.20, 0.21, 0.22, 0.23, 0.24, 0.25"
-FastGaussQuadrature = "^0.3.2, 0.4"
+DataStructures = "0.14.2 - 0.18"
+Distributions = "0.19 - 0.25"
+FastGaussQuadrature = "0.3.2 - 0.4"
 JuMP = "0.22"
 LeftChildRightSiblingTrees = "0.1"
 MutableArithmetics = "0.3"
-Reexport = "0.2, 1"
-SpecialFunctions = "0.8, 0.9, 0.10, 1, 2"
-julia = "^1.1"
+Reexport = "0.2 - 1"
+SpecialFunctions = "0.8 - 2"
+julia = "^1.6"
 
 [extras]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/docs/src/develop/start_guide.md
+++ b/docs/src/develop/start_guide.md
@@ -27,7 +27,7 @@ through step by step how this should be done.
   3. Fork the `InfiniteOpt` repository to your GitHub account. Only core 
      developers have permissions to modify `InfiniteOpt` directly, thus others need 
      to fork it which essentially amounts to creating their own linked copy. This is 
-     done by clicking the `Fork` button at the top left corner on the main repository 
+     done by clicking the `Fork` button in the top left corner on the main repository 
      page [here](https://github.com/pulsipher/InfiniteOpt.jl).
   4. Install Git on your computer. Git is an open source version control program 
      for repositories (it is why GitHub uses the word Git). This is needed to manipulate 
@@ -38,7 +38,7 @@ through step by step how this should be done.
      computer. This needs to be done via the `dev` command in the package manager 
      so you can edit it. The syntax is as follows:
      ```julia
-     (v1.6) pkg> dev https://github.com/username-here/InfiniteOpt.jl
+     (v1.7) pkg> dev https://github.com/username-here/InfiniteOpt.jl
      ```
      We also recommend you install [`Revise.jl`](https://github.com/timholy/Revise.jl) 
      which is very useful when developing packages in Julia.

--- a/docs/src/install.md
+++ b/docs/src/install.md
@@ -8,7 +8,7 @@ found [here](https://julialang.org/downloads/). We recommend using
 [VSCode](https://www.julia-vscode.org/) to edit and run Julia scripts.
 
 !!! note
-    This version of `InfiniteOpt` requires that Julia 1.1 or newer be used.
+    This version of `InfiniteOpt` requires that Julia 1.6 or newer be used.
 
 !!! tip
     We recommend installing the latest version of Julia. However, for users that 

--- a/test/nlp.jl
+++ b/test/nlp.jl
@@ -516,9 +516,7 @@ end
     # test the sum 
     @testset "sum" begin 
         # test empty sums
-        if Base.VERSION >= v"1.6"
-            @test sum(i for i in Int[]) == 0
-        end
+        @test sum(i for i in Int[]) == 0
         @test isequal(sum(NLPExpr[]), zero(NLPExpr))
         @test isequal(sum(GeneralVariableRef[]), 
                       zero(GenericAffExpr{Float64, GeneralVariableRef}))
@@ -538,9 +536,7 @@ end
     # test the product
     @testset "prod" begin 
         # test empty sums
-        if Base.VERSION >= v"1.6"
-            @test prod(i for i in Int[]) == 1
-        end
+        @test prod(i for i in Int[]) == 1
         @test isequal(prod(NLPExpr[]), one(NLPExpr))
         # test NLP sums 
         p = Node(NodeData(:sin))


### PR DESCRIPTION
This follows up from #182 to now require 1.6 and drop support for all previous versions.