### PR TITLE
Minor Keyword Argument Fix with 𝔼

### DIFF
--- a/docs/src/develop/extensions.md
+++ b/docs/src/develop/extensions.md
@@ -1030,7 +1030,7 @@ julia> result_count(model)
 
 julia> value.(y)
 2-element Vector{Float64}:
- 0.0
+ -9.164638781941642e-9
  1.224744871391589
 
 julia> optimizer_index(z)

--- a/docs/src/develop/extensions.md
+++ b/docs/src/develop/extensions.md
@@ -1031,7 +1031,7 @@ julia> result_count(model)
 julia> value.(y)
 2-element Vector{Float64}:
  -9.164638781941642e-9
- 1.224744871391589
+  1.224744871391589
 
 julia> optimizer_index(z)
 MathOptInterface.VariableIndex(3)

--- a/src/MeasureToolbox/expectations.jl
+++ b/src/MeasureToolbox/expectations.jl
@@ -237,9 +237,10 @@ A convenient wrapper for [`expect`](@ref). The unicode symbol `𝔼` is produced
 """
 function 𝔼(expr::JuMP.AbstractJuMPScalar,
     prefs::Union{InfiniteOpt.GeneralVariableRef, AbstractArray{InfiniteOpt.GeneralVariableRef}};
-    num_supports::Int = InfiniteOpt.DefaultNumSupports
+    num_supports::Int = InfiniteOpt.DefaultNumSupports,
+    kwargs...
     )::InfiniteOpt.GeneralVariableRef
-    return expect(expr, prefs, num_supports = num_supports)
+    return expect(expr, prefs; num_supports = num_supports, kwargs...)
 end
 
 """

--- a/test/MeasureToolbox/expectations.jl
+++ b/test/MeasureToolbox/expectations.jl
@@ -52,6 +52,10 @@ end
     @test !InfiniteOpt._is_expect(InfiniteOpt._core_variable_object(expect(inf, y)).data)
     @test 𝔼(inf, x) isa GeneralVariableRef
 
+    # test with new pdf 
+    @test expect(y, y, pdf = y -> 1) isa GeneralVariableRef
+    @test 𝔼(y, y, pdf = y -> 1) isa GeneralVariableRef
+
     # Test with JuMP container 
     @infinite_parameter(m, z[2:3] in [-1, 1])
     @test_throws ErrorException expect(z[2], z)


### PR DESCRIPTION
This fixes a bug that `𝔼` didn't accept the `pdf` keyword