### PR TITLE
Remove `max` and `min` as default NLP functions

### DIFF
--- a/docs/src/guide/expression.md
+++ b/docs/src/guide/expression.md
@@ -41,7 +41,7 @@ julia> @infinite_parameter(model, t in [0, 10]);
 julia> @parameter_function(model, f == sin(t))
 f(t)
 ```
-Here we created an parameter function object, added it to `model`, and 
+Here we created a parameter function object, added it to `model`, and 
 then created a Julia variable `f` that serves as a `GeneralVariableRef` that points 
 to it. From here we can treat `f` as a normal infinite variable and use it with 
 measures, derivatives, and constraints. For example, we can do the following:
@@ -58,7 +58,7 @@ julia> @constraint(model, y - f <= 0)
 y(t) - f(t) ≤ 0.0, ∀ t ∈ [0, 10]
 ```
 We can also define parameter functions that depend on multiple infinite 
-parameters even use an anonymous function if prefer:
+parameters even use an anonymous function if preferred:
 ```jldoctest param_func
 julia> @infinite_parameter(model, x[1:2] in [-1, 1]);
 
@@ -77,7 +77,7 @@ julia> @parameter_function(model, pfunc_alt[i = 1:3] == t -> mysin(t, as[i], b =
  pfunc_alt[3](t)
 ```
 The main recommended use case for [`parameter_function`](@ref) is that it is 
-amendable to defining complex anonymous functions via a do-block which is useful 
+amenable to define complex anonymous functions via a do-block which is useful 
 for applications like defining a time-varied setpoint:
 ```jldoctest param_func
 julia> setpoint = parameter_function(t, name = "setpoint") do t_supp
@@ -92,7 +92,7 @@ setpoint(t)
 Please consult the following links for more information about defining parameter 
 functions: [`@parameter_function`](@ref) and [`parameter_function`](@ref).
 
-Beyond this, there are number of query and modification methods that can be 
+Beyond this, there are a number of query and modification methods that can be 
 employed for parameter functions and these are detailed in the 
 [technical manual](@ref par_func_manual) Section below.
 
@@ -263,12 +263,12 @@ More information can be found in the documentation for quadratic expressions in
 ## [Nonlinear Expressions](@id nlp_guide)
 General nonlinear expressions as generated via `JuMP.@NLexpression`, 
 `JuMP.@NLobjective`, and/or `JuMP.@NLconstraint` macros in `JuMP` are not 
-extendible for extension packages like `InfiniteOpt`. A fundamental 
+extendable for extension packages like `InfiniteOpt`. A fundamental 
 overhaul is planned to resolve this problem (check the status on 
 [GitHub](https://github.com/jump-dev/MathOptInterface.jl/issues/846)), but this 
 will likely require 1-3 years to resolve.
 
-Thus in the interim, we circumvent this problem in `InfiniteOpt` by implementing 
+Thus, in the interim, we circumvent this problem in `InfiniteOpt` by implementing 
 our own general nonlinear expression API. However, we will see that our interface 
 treats nonlinear expressions as 1st class citizens and thus is generally more 
 convenient then using `JuMP`'s current legacy nonlinear modeling interface. 
@@ -281,13 +281,13 @@ We discuss the ins and outs of this interface in the subsections below.
 
 !!! warning
     Our new general nonlinear modeling interface is experimental and thus is 
-    subject to change to address any unintented behavior. Please notify us on 
+    subject to change to address any unintended behavior. Please notify us on 
     GitHub if you encounter any unexpected behavior.
 
 ### Basic Usage 
 In `InfiniteOpt` we can define nonlinear expressions in similar manner to how 
 affine/quadratic expressions are made in `JuMP`. For instance, we can make an 
-expression using normal Julia code outside of a macro:
+expression using normal Julia code outside a macro:
 ```jldoctest nlp; setup = :(using InfiniteOpt; model = InfiniteModel())
 julia> @infinite_parameter(model, t ∈ [0, 1]); @variable(model, y, Infinite(t));
 
@@ -315,7 +315,7 @@ constr : (y(t)^y(t) * sin(y(t)) + y(t)^3 + y(t)^4) - 3 = 0.0, ∀ t ∈ [0, 1]
 
 !!! note
     The `@NLexpression`, `@NLobjective`, and `@NLconstraint` macros used by `JuMP`
-    are not supported by `InfiniteOpt`. Instead we can more conveniently use the 
+    are not supported by `InfiniteOpt`. Instead, we can more conveniently use the 
     `@expression`, `@objective`, and `@constraint` macros directly.
 
 Natively, we support all the same nonlinear functions/operators that `JuMP` 
@@ -468,10 +468,10 @@ h(y(t), 42)
 
 !!! tip
     Where possible it is preferred to use function tracing instead of function 
-    registration. This improves performance and can prevent unintential errors. 
+    registration. This improves performance and can prevent unintentional errors. 
     See [Function Tracing](@ref) for more details.
 
-To highlight the differnce between function tracing and function 
+To highlight the difference between function tracing and function 
 registration consider the following example:
 ```jldoctest nlp
 julia> f(a) = a^3;
@@ -491,7 +491,7 @@ behind the scenes via auto-differentiation with the selected optimizer model
 backend). However, again please note that in this case tracing is preferred 
 since `f` can be traced. 
 
-Let's consider a more realistic example where the function is not amendable to 
+Let's consider a more realistic example where the function is not amenable to 
 tracing:
 ```jldoctest nlp
 julia> function g(a)
@@ -526,7 +526,7 @@ julia> my_eta(y)
 my_eta(y(t))
 ```
 Notice that we cannot register `SpecialFunctions.eta` directly due to 
-scoping limitations that are inherit in generating constructor functions on the 
+scoping limitations that are inherited in generating constructor functions on the 
 fly (which necessarily occurs behind the scenes with [`@register`](@ref)).
 
 Now in some cases we might wish to specify the gradient and hessian of a 
@@ -619,7 +619,7 @@ by the API of
 
 In addition to the API of `LeftChildRightSiblingTrees.jl`, we provide some 
 mapping functions that are useful for extensions. First, with 
-[`map_expression`](@ref) we can create a new `NLPExpr` based on an exisiting 
+[`map_expression`](@ref) we can create a new `NLPExpr` based on an existing 
 `NLPExpr` where a transformation is applied to each variable:
 ```jldoctest nlp
 julia> map_expression(v -> v^2, expr)

--- a/src/nlp.jl
+++ b/src/nlp.jl
@@ -926,21 +926,6 @@ for (name, func) in _Base1ArgFuncList
     end
 end
 
-# Setup the Base functions with 2 arguments
-for (name, func) in (:min => min, :max => max)
-    # add it to the main storage dict
-    _NativeNLPFunctions[(name, 2)] = func
-    # make an expression constructor
-    @eval begin 
-        function Base.$name(
-            v1::Union{AbstractInfOptExpr, Real}, 
-            v2::Union{AbstractInfOptExpr, Real}
-            )
-            return NLPExpr(_call_graph($(quot(name)), v1, v2))
-        end
-    end
-end
-
 # Setup the ifelse function
 _NativeNLPFunctions[(:ifelse, 3)] = Core.ifelse
 

--- a/test/array_parameters.jl
+++ b/test/array_parameters.jl
@@ -459,7 +459,7 @@ end
         # test with same data 
         @test InfiniteOpt._adaptive_data_update(prefs[1], params, data) isa Nothing
         # test with different data 
-        domain = MultiDistributionDomain(MvNormal([0, 0], [1, 1]))
+        domain = MultiDistributionDomain(MvNormal([0, 0], LinearAlgebra.Diagonal(map(abs2, [1, 1]))))
         ps = DependentParameters(domain, Dict{Vector{Float64}, Set{DataType}}(), 10, methods)
         @test InfiniteOpt._adaptive_data_update(prefs[2], ps, data) isa Nothing
         @test InfiniteOpt._core_variable_object(prefs[2]) == ps

--- a/test/deletion.jl
+++ b/test/deletion.jl
@@ -474,7 +474,7 @@ end
     @constraint(m, con1, x + y + par <= 0)
     con2 = add_constraint(m, ScalarConstraint(y, MOI.LessThan(0.)))
     @constraint(m, con3, [x, y] in MOI.Zeros(2))
-    @constraint(m, con4, max(par, x) <= 0)
+    @constraint(m, con4, sin(x) <= 0)
     @objective(m, Min, x + y)
     # test deletion of x
     @test isa(delete(m, x), Nothing)
@@ -482,7 +482,7 @@ end
     @test isequal_canonical(measure_function(meas1), y + par)
     @test isequal_canonical(jump_function(constraint_object(con1)), y + par)
     @test isequal_canonical(objective_function(m), y + 0)
-    @test isequal_canonical(jump_function(constraint_object(con4)), max(par, 0))
+    @test isequal_canonical(jump_function(constraint_object(con4)), sin(zero(NLPExpr)))
     @test !is_valid(m, con3)
     @test !haskey(InfiniteOpt._data_dictionary(m, FiniteVariable), JuMP.index(x))
     # test deletion of y

--- a/test/expressions.jl
+++ b/test/expressions.jl
@@ -691,13 +691,13 @@ end
     @testset "NLPExpr" begin 
         # make expressions 
         nlp1 = sin(3pt)
-        nlp2 = pt^2.3 + max(inf, pt)
+        nlp2 = pt^2.3 + <=(inf, pt)
         nlp3 = cos(pt^2 + pt) / (2pt + 2inf)
         # test expressions 
         @test InfiniteOpt._remove_variable(nlp1, pt) isa Nothing 
         @test isequal(nlp1, sin(zero(zero(GenericAffExpr{Float64, GeneralVariableRef}))))
         @test InfiniteOpt._remove_variable(nlp2, pt) isa Nothing 
-        @test isequal(nlp2, zero(NLPExpr)^2.3 + max(inf, 0.0))
+        @test isequal(nlp2, zero(NLPExpr)^2.3 + <=(inf, 0.0))
         @test InfiniteOpt._remove_variable(nlp3, inf) isa Nothing 
         @test isequal(nlp3, cos(pt^2 + pt) / (2pt))
     end

--- a/test/macro_expressions.jl
+++ b/test/macro_expressions.jl
@@ -82,7 +82,6 @@
         @test isequal(@expression(m, pt / inf), pt * (1 / inf))
         @test isequal(@expression(m, pt ^ inf), pt ^ inf)
         @test isequal(@expression(m, 2 ^ inf), 2 ^ inf)
-        @test isequal(@expression(m, max(inf, meas)), max(inf, meas))
         @test isequal(@expression(m, abs(pt)), abs(pt))
     end
 end
@@ -171,7 +170,6 @@ end
     @testset "Nonlinear" begin
         @test isequal(@expression(m, pt / aff1), pt * (1 / aff1))
         @test isequal(@expression(m, pt ^ aff1), pt ^ aff1)
-        @test isequal(@expression(m, max(inf, aff1)), max(inf, aff1))
         @test isequal(@expression(m, abs(aff1)), abs(aff1))
     end
 end
@@ -260,7 +258,6 @@ end
     @testset "Nonlinear" begin
         @test isequal(@expression(m, aff1 / pt), aff1 * (1 / pt))
         @test isequal(@expression(m, aff1 ^ pt), aff1 ^ pt)
-        @test isequal(@expression(m, max(aff1, pt)), max(aff1, pt))
     end
 end
 
@@ -410,7 +407,6 @@ end
     @testset "Nonlinear" begin
         @test isequal(@expression(m, aff1 / aff1), aff1 * (1 / aff1))
         @test isequal(@expression(m, aff1 ^ aff1), aff1 ^ aff1)
-        @test isequal(@expression(m, max(aff1, aff1)), max(aff1, aff1))
     end
 end
 
@@ -518,7 +514,6 @@ end
         @test isequal(@expression(m, quad1 * pt), quad1 * pt)
         @test isequal(@expression(m, quad1 / pt), quad1 * (1 / pt))
         @test isequal(@expression(m, quad1 ^ pt), quad1 ^ pt)
-        @test isequal(@expression(m, max(quad1, pt)), max(quad1, pt))
         @test isequal(@expression(m, abs(quad1)), abs(quad1))
     end
 end
@@ -626,7 +621,6 @@ end
         @test isequal(@expression(m, pt * quad1),  pt * quad1)
         @test isequal(@expression(m, pt / quad1), pt * (1 / quad1))
         @test isequal(@expression(m, pt ^ quad1), pt ^ quad1)
-        @test isequal(@expression(m, max(pt, quad1)), max(pt, quad1))
     end
 end
 
@@ -745,7 +739,6 @@ end
         @test isequal(@expression(m, aff1 * quad1),  aff1 * quad1)
         @test isequal(@expression(m, aff1 / quad1), aff1 * (1 / quad1))
         @test isequal(@expression(m, aff1 ^ quad1), aff1 ^ quad1)
-        @test isequal(@expression(m, max(aff1, quad1)), max(aff1, quad1))
     end
 end
 
@@ -865,7 +858,6 @@ end
         @test isequal(@expression(m, quad1 * aff1), quad1 * aff1)
         @test isequal(@expression(m, quad1 / aff1), quad1 * (1 / aff1))
         @test isequal(@expression(m, quad1 ^ aff1), quad1 ^ aff1)
-        @test isequal(@expression(m, max(quad1, aff1)), max(quad1, aff1))
     end
 end
 
@@ -971,7 +963,6 @@ end
         @test isequal(@expression(m, quad1 * quad1), quad1 * quad1)
         @test isequal(@expression(m, quad1 / quad1), quad1 * (1 / quad1))
         @test isequal(@expression(m, quad1 ^ quad1), quad1 ^ quad1)
-        @test isequal(@expression(m, max(quad1, quad1)), max(quad1, quad1))
     end
 end
 
@@ -1001,6 +992,5 @@ end
     # test function calls
     @testset "Functions" begin
         @test isequal(@expression(m, sin(y) + nlp), sin(y) + nlp)
-        @test isequal(@expression(m, 2y - max(0, y^2)), 2y - max(0, y^2))
     end
 end

--- a/test/nlp.jl
+++ b/test/nlp.jl
@@ -723,16 +723,6 @@ end
             @test isequal(f(i), expected)
             end
         end
-        for i in [42, y, aff, quad, nlp]
-            for j in [42, y, aff, quad, nlp]
-                for (n, f) in [(:max, max), (:min, min)]
-                    if !(isequal(i, 42) && isequal(j, 42))
-                        expected = NLPExpr(InfiniteOpt._call_graph(n, i, j))
-                        @test isequal(f(i, j), expected)
-                    end
-                end
-            end
-        end
     end
 end
 

--- a/test/nlp.jl
+++ b/test/nlp.jl
@@ -282,9 +282,8 @@ end
         p.child.data = NodeData(0)
         @test InfiniteOpt._is_zero(p)
         # test function 
-        p = Node(NodeData(:max))
+        p = Node(NodeData(:abs))
         addchild(p, NodeData(0))
-        addchild(p, NodeData(0)) 
         @test InfiniteOpt._is_zero(p)
         p.child.data = NodeData(y)
         @test !InfiniteOpt._is_zero(p)
@@ -1011,7 +1010,7 @@ end
         @test string((z*z) ^ 4) == "(z²)^4"
         @test string((cos(z) + sin(z)) / y) == "(cos(z) + sin(z)) / y(t)"
         @test string(-cos(z + y) * z^2.3) == "-cos(z + y(t)) * z^2.3"
-        @test string((-max(0, z)) ^ 3) == "(-(max(0, z))^3"
+        @test string((-InfiniteOpt.ifelse(z, 0, z)) ^ 3) == "(-(ifelse(z, 0, z))^3"
         # test AffExpr cases 
         aff0 = zero(GenericAffExpr{Float64, GeneralVariableRef})
         @test string(aff0^4 + (2z - 3y + 42) ^ (-1z)) == "0^4 + (2 z - 3 y(t) + 42)^(-z)"

--- a/test/nlp.jl
+++ b/test/nlp.jl
@@ -1010,7 +1010,7 @@ end
         @test string((z*z) ^ 4) == "(z²)^4"
         @test string((cos(z) + sin(z)) / y) == "(cos(z) + sin(z)) / y(t)"
         @test string(-cos(z + y) * z^2.3) == "-cos(z + y(t)) * z^2.3"
-        @test string((-InfiniteOpt.ifelse(z, 0, z)) ^ 3) == "(-(ifelse(z, 0, z))^3"
+        @test string((-InfiniteOpt.ifelse(z == 0, 0, z)) ^ 3) == "(-(ifelse(z == 0, 0, z))^3"
         # test AffExpr cases 
         aff0 = zero(GenericAffExpr{Float64, GeneralVariableRef})
         @test string(aff0^4 + (2z - 3y + 42) ^ (-1z)) == "0^4 + (2 z - 3 y(t) + 42)^(-z)"


### PR DESCRIPTION
This follows from https://github.com/jump-dev/JuMP.jl/pull/2842.

Until JuMP.jl releases this bug fix in the next version, we can use the work around:
```julia
using InfiniteOpt
model = InfiniteModel()
@variable(model, z)
my_max(a...) = max(a...)
@register(model, my_max(a, b))
@objective(model, Min, my_max(0, z))
```

Once, JuMP.jl is updated then we can just register as normal:
```julia
using InfiniteOpt
model = InfiniteModel()
@variable(model, z)
@register(model, max(a, b))
@objective(model, Min, max(0, z))
```