### PR TITLE
Drop Use of `nl_` String Functions

### DIFF
--- a/test/TranscriptionOpt/model.jl
+++ b/test/TranscriptionOpt/model.jl
@@ -506,14 +506,14 @@ end
         @test IOTO.transcription_expression(tm, expr, [1., 1., 1.]) == expected
         # test becomes a nonlinear expression
         expr = meas2 * x0
-        @test IOTO.transcription_expression(tm, expr, [1., 1., 1.]) isa NonlinearExpression
-        @test nl_expr_string(tm, MIME("text/plain"), tm.nlp_data.nlexpr[end]) == "+((+(-2.0 * a) + b * b + d * d) * b)"
+        expected = "subexpression[1]: +((+(-2.0 * a) + b * b + d * d) * b)"
+        @test sprint(show, IOTO.transcription_expression(tm, expr, [1., 1., 1.])) == expected
     end
     # test transcription expression for NLPExprs with 3 args
     @testset "transcription_expression (NLPExpr)" begin
         expr = sin(y)
-        @test IOTO.transcription_expression(tm, expr, [1., 1., 1.]) isa NonlinearExpression
-        @test nl_expr_string(tm, MIME("text/plain"), tm.nlp_data.nlexpr[end]) == "sin(a)"
+        expected = "subexpression[2]: sin(a)"
+        @test sprint(show, IOTO.transcription_expression(tm, expr, [1., 1., 1.])) == expected
     end
     # test transcription expression for numbers with 3 args
     @testset "transcription_expression (Real)" begin
@@ -536,8 +536,8 @@ end
         @test IOTO.transcription_expression(tm, expr) == expected
         @test IOTO.transcription_expression(tm, expr, ndarray = true) == [expected]
         # test NLPExpr 
-        @test IOTO.transcription_expression(tm, sin(x0)) isa NonlinearExpression
-        @test nl_expr_string(tm, MIME("text/plain"), tm.nlp_data.nlexpr[end]) == "sin(b)"
+        expected = "subexpression[3]: sin(b)"
+        @test sprint(show, IOTO.transcription_expression(tm, sin(x0))) == expected
     end
     # test transcription expression for variables with 2 args
     @testset "transcription_expression (Variable 2 Args)" begin

--- a/test/TranscriptionOpt/transcribe.jl
+++ b/test/TranscriptionOpt/transcribe.jl
@@ -222,7 +222,7 @@ end
         @test IOTO.transcribe_objective!(tm, m) isa Nothing 
         @test objective_sense(tm) == MOI.MAX_SENSE
         @test objective_function_string(MIME("text/plain"), tm) == "subexpression[1] + 0.0"
-        @test nl_expr_string(tm, MIME("text/plain"), tm.nlp_data.nlexpr[end]) == "z ^ 4.0"
+        @test sprint(show, NonlinearExpression(tm, 1)) == "subexpression[1]: z ^ 4.0"
     end
 end
 
@@ -322,11 +322,10 @@ end
         con = constraint_object(c7)
         func = jump_function(con)
         set = moi_set(con)
-        @test IOTO._process_constraint(tm, con, func, set, zeros(3), "test1") isa NonlinearConstraintRef 
         expected = Sys.iswindows() ? "subexpression[1] - 0.0 == 0" : "subexpression[1] - 0.0 = 0"
-        @test nl_constraint_string(tm, MIME("text/plain"), tm.nlp_data.nlconstr[end]) == expected
+        @test sprint(show, IOTO._process_constraint(tm, con, func, set, zeros(3), "test1")) == expected
         expected = ["sin(z) ^ x(support: 1) - 0.0", "sin(z) ^ x(support: 2) - 0.0"]
-        @test nl_expr_string(tm, MIME("text/plain"), tm.nlp_data.nlexpr[end]) in expected
+        @test sprint(show, NonlinearExpression(tm, 1)) in expected
         tm.nlp_data = nothing
         # vector constraint 
         con = constraint_object(c6)

--- a/test/TranscriptionOpt/transcribe.jl
+++ b/test/TranscriptionOpt/transcribe.jl
@@ -324,7 +324,8 @@ end
         set = moi_set(con)
         expected = Sys.iswindows() ? "subexpression[1] - 0.0 == 0" : "subexpression[1] - 0.0 = 0"
         @test sprint(show, IOTO._process_constraint(tm, con, func, set, zeros(3), "test1")) == expected
-        expected = ["sin(z) ^ x(support: 1) - 0.0", "sin(z) ^ x(support: 2) - 0.0"]
+        expected = ["subexpression[1]: sin(z) ^ x(support: 1) - 0.0", 
+                    "subexpression[1]: sin(z) ^ x(support: 2) - 0.0"]
         @test sprint(show, NonlinearExpression(tm, 1)) in expected
         tm.nlp_data = nothing
         # vector constraint 


### PR DESCRIPTION
This follows from https://github.com/jump-dev/JuMP.jl/pull/2893.
