### PR TITLE
Improve `DiscreteMeasureData` Tutorial

### DIFF
--- a/docs/src/develop/extensions.md
+++ b/docs/src/develop/extensions.md
@@ -312,22 +312,21 @@ evaluation methods, users may want to embed the new evaluation method under the
 ### Creating a DiscreteMeasureData Object
 The basic way to do that is to write a function that creates 
 [`DiscreteMeasureData`](@ref) object and pass the object to [`measure`](@ref). 
-For instance, let's consider defining a function that enables the definition of a 
-uniform grid for a univariate or multivariate infinite parameter in 
-[`IntervalDomain`](@ref). The function, denoted `uniform_grid`, generates uniform 
-grid points as supports for univariate parameter and each component of 
-independent multivariate parameter. The univariate version of this function 
-can be defined as follows:
-
+This considers a measure approximation of the form:
+```math
+\sum_{i \in I} \alpha_i f(\tau_i) w(\tau_i)
+```
+where ``\alpha_i`` are coefficients, ``f(\cdot)`` is the expression being measured, 
+``w(\cdot)`` is a weighting function, and ``i \in I`` indexes the support points. 
+Let's consider defining a function that enables the definition of a 
+uniform grid for a univariate infinite parameter in [`IntervalDomain`](@ref). 
+This example approximation uses a uniformly spaced supports ``\tau_i`` with 
+``\alpha_i = \frac{ub - lb}{|I|}``:
 ```jldoctest measure_eval; output = false, setup = :(using InfiniteOpt)
-function uniform_grid(
-    param::GeneralVariableRef, 
-    lb::Real, 
-    ub::Real, 
-    num_supports::Int
-    )::DiscreteMeasureData
-    increment = (ub - lb) / (num_supports - 1)
-    supps = [lb + (i - 1) * increment for i in 1:num_supports]
+function uniform_grid(param, num_supports)
+    lb = lower_bound(param)
+    ub = upper_bound(param)
+    supps = collect(LinRange(lb, ub, num_supports))
     coeffs = ones(num_supports) / num_supports * (ub - lb)
     return DiscreteMeasureData(param, coeffs, supps, lower_bound = lb, upper_bound = ub)
 end
@@ -352,7 +351,7 @@ Now we can use `uniform_grid` to construct a [`DiscreteMeasureData`](@ref) and
 create a measure using the measure data, as shown below:
 
 ```jldoctest measure_eval
-julia> tdata = uniform_grid(t, 0, 5, 6);
+julia> tdata = uniform_grid(t, 6);
 
 julia> y_meas = measure(y, tdata)
 measure{t ∈ [0, 5]}[y(t)]


### PR DESCRIPTION
This cleans up the extension tutorial on using `DiscreteMeasureData` and makes it more clear.
